### PR TITLE
Many fixes and improvements

### DIFF
--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -78,28 +78,28 @@
 //==========================================================================
 
 #if defined OVERRIDE_NATIVE_GAMETEXT
-    #define GAMETEXT_STYLE_MIN      0
+    #define MIN_GAMETEXT_STYLE      0
 #else
-    #define GAMETEXT_STYLE_MIN      7
+    #define MIN_GAMETEXT_STYLE      7
 #endif
 
 #define     MAX_GAMETEXT_LENGTH     256
 #define     GAMETEXT_LEGACY         6
-#define     GAMETEXT_STYLE_MAX      17
+#define     MAX_GAMETEXT_STYLE      17
 #define     FADE_INTERVAL           50
 #define     FADE_ALPHA_STEP         0x12
 
 static
-    Text:gs_GameTextStyle[GAMETEXT_STYLE_MAX + 1],
-    PlayerText:gs_PlayerGameTextStyle[MAX_PLAYERS][GAMETEXT_STYLE_MAX + 1],
-    gs_GameTextTimer[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    gs_GameTextFadeOutTimer[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    gs_GameTextFadeInTimer[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    gs_GameTextOriginalColor[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    gs_GameTextOriginalBGColor[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    gs_GameTextOriginalBoxColor[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    bool:gs_GameTextIsFadingOut[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
-    bool:gs_GameTextIsFadingIn[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1]
+    Text:gs_GameTextStyle[MAX_GAMETEXT_STYLE + 1],
+    PlayerText:gs_PlayerGameTextStyle[MAX_PLAYERS][MAX_GAMETEXT_STYLE + 1],
+    gs_GameTextTimer[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    gs_GameTextFadeOutTimer[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    gs_GameTextFadeInTimer[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    gs_GameTextOriginalColor[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    gs_GameTextOriginalBGColor[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    gs_GameTextOriginalBoxColor[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    bool:gs_GameTextIsFadingOut[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1],
+    bool:gs_GameTextIsFadingIn[MAX_GAMETEXT_STYLE + 1][MAX_PLAYERS + 1]
 ;
 
 //==========================================================================
@@ -975,14 +975,14 @@ static stock OnDestroyGameText(playerid)
 {
     if (playerid == INVALID_PLAYER_ID)
     {
-        for (new style = GAMETEXT_STYLE_MIN; style <= GAMETEXT_STYLE_MAX; style++)
+        for (new style = MIN_GAMETEXT_STYLE; style <= MAX_GAMETEXT_STYLE; style++)
         {
             TextDrawDestroy(gs_GameTextStyle[style]);
         }
     }
     else
     {
-        for (new style = GAMETEXT_STYLE_MIN; style <= GAMETEXT_STYLE_MAX; style++)
+        for (new style = MIN_GAMETEXT_STYLE; style <= MAX_GAMETEXT_STYLE; style++)
         {
             PlayerTextDrawDestroy(playerid, gs_PlayerGameTextStyle[playerid][style]);
         }
@@ -1002,10 +1002,10 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     if (!IsPlayerConnected(playerid)) return false;
 
     #if defined OVERRIDE_NATIVE_GAMETEXT
-        if (!(GAMETEXT_STYLE_MIN <= style <= GAMETEXT_STYLE_MAX)) return false;
+        if (!(MIN_GAMETEXT_STYLE <= style <= MAX_GAMETEXT_STYLE)) return false;
     #else
         // Allow native styles 0-6 to pass through to native functions
-        if (!(0 <= style <= GAMETEXT_STYLE_MAX)) return false;
+        if (!(0 <= style <= MAX_GAMETEXT_STYLE)) return false;
     #endif
 
     const static_args = 4;
@@ -1147,10 +1147,10 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
 stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
 {
     #if defined OVERRIDE_NATIVE_GAMETEXT
-        if (!(GAMETEXT_STYLE_MIN <= style <= GAMETEXT_STYLE_MAX)) return false;
+        if (!(MIN_GAMETEXT_STYLE <= style <= MAX_GAMETEXT_STYLE)) return false;
     #else
         // Allow native styles 0-6 to pass through to native functions
-        if (!(0 <= style <= GAMETEXT_STYLE_MAX)) return false;
+        if (!(0 <= style <= MAX_GAMETEXT_STYLE)) return false;
     #endif
 
     const static_args = 3;
@@ -1463,7 +1463,7 @@ public OnPlayerConnect(playerid)
 
 public OnPlayerDisconnect(playerid, reason)
 {
-    for (new style = GAMETEXT_STYLE_MIN; style <= GAMETEXT_STYLE_MAX; style++)
+    for (new style = MIN_GAMETEXT_STYLE; style <= MAX_GAMETEXT_STYLE; style++)
     {
         if (gs_GameTextFadeOutTimer[style][playerid])
         {

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -928,7 +928,7 @@ static stock GameTextEx(playerid)
 forward OnHideGameText(playerid, styleid);
 public OnHideGameText(playerid, styleid)
 {
-    if (9 <= styleid <= 10 || styleid == 14)
+    if (3 <= styleid <= 6 || 9 <= styleid <= 14 || styleid == 17)
     {
         if (playerid == MAX_PLAYERS)
         {
@@ -1075,7 +1075,7 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     gs_GameTextIsFadingOut[style][playerid] = false;
     gs_GameTextIsFadingIn[style][playerid] = false;
 
-    if (!(9 <= style <= 10) && style != 14)
+    if (!(3 <= style <= 6) && !(9 <= style <= 14) && style != 17)
     {
         gs_GameTextOriginalColor[style][playerid] = PlayerTextDrawGetColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
         gs_GameTextOriginalBGColor[style][playerid] = PlayerTextDrawGetBackgroundCol(playerid, gs_PlayerGameTextStyle[playerid][style]);
@@ -1121,7 +1121,7 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
         #endif
     }
 
-    if (9 <= style <= 10 || style == 14)
+    if (3 <= style <= 6 || 9 <= style <= 14 || style == 17)
     {
         PlayerTextDrawShow(playerid, gs_PlayerGameTextStyle[playerid][style]);
     }
@@ -1220,7 +1220,7 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
     gs_GameTextIsFadingOut[style][MAX_PLAYERS] = false;
     gs_GameTextIsFadingIn[style][MAX_PLAYERS] = false;
 
-    if (!(9 <= style <= 10) && style != 14)
+    if (!(3 <= style <= 6) && !(9 <= style <= 14) && style != 17)
     {
         gs_GameTextOriginalColor[style][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[style]);
         gs_GameTextOriginalBGColor[style][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[style]);
@@ -1266,7 +1266,7 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
         #endif
     }
 
-    if (9 <= style <= 10 || style == 14)
+    if (3 <= style <= 6 || 9 <= style <= 14 || style == 17)
     {
         TextDrawShowForAll(gs_GameTextStyle[style]);
     }
@@ -1322,7 +1322,7 @@ public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, b
         {
             TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);
             TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha);
-            if (!(9 <= styleid <= 10) && styleid != 14)
+            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
             {
                 TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);
             }
@@ -1332,7 +1332,7 @@ public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, b
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | colourAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | backgroundColourAlpha);
-            if (!(9 <= styleid <= 10) && styleid != 14)
+            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | boxColourAlpha);
             }
@@ -1379,7 +1379,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);
             TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha);
-            if (!(9 <= styleid <= 10) && styleid != 14)
+            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
             {
                 TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);
             }
@@ -1389,7 +1389,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | colourAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | backgroundColourAlpha);
-            if (!(9 <= styleid <= 10) && styleid != 14)
+            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | boxColourAlpha);
             }
@@ -1410,7 +1410,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | origColorAlpha);
             TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | origBGAlpha);
-            if (!(9 <= styleid <= 10) && styleid != 14)
+            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
             {
                 TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | origBoxAlpha);
             }
@@ -1420,7 +1420,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | origColorAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | origBGAlpha);
-            if (!(9 <= styleid <= 10) && styleid != 14)
+            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | origBoxAlpha);
             }

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -109,12 +109,12 @@ static
 #if defined _ALS_GameTextForPlayer
     #error _ALS_GameTextForPlayer defined
 #endif
-native BAD_GameTextForPlayer(playerid, const string[], time, style) = GameTextForPlayer;
+native ORIG_GameTextForPlayer(playerid, const string[], time, style) = GameTextForPlayer;
 
 #if defined _ALS_GameTextForAll
     #error _ALS_GameTextForAll defined
 #endif
-native BAD_GameTextForAll(const string[], time, style) = GameTextForAll;
+native ORIG_GameTextForAll(const string[], time, style) = GameTextForAll;
 
 //==========================================================================
 //                       TEXTDRAW COLOR STORAGE
@@ -1043,11 +1043,11 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
                 #emit LCTRL 5
                 #emit SCTRL 4
 
-                return BAD_GameTextForPlayer(playerid, string, time, style);
+                return ORIG_GameTextForPlayer(playerid, string, time, style);
             }
             else
             {
-                return BAD_GameTextForPlayer(playerid, text, time, style);
+                return ORIG_GameTextForPlayer(playerid, text, time, style);
             }
         }
     #endif
@@ -1188,11 +1188,11 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
                 #emit LCTRL 5
                 #emit SCTRL 4
 
-                return BAD_GameTextForAll(string, time, style);
+                return ORIG_GameTextForAll(string, time, style);
             }
             else
             {
-                return BAD_GameTextForAll(text, time, style);
+                return ORIG_GameTextForAll(text, time, style);
             }
         }
     #endif

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -1013,7 +1013,9 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     const static_args = 4;
     const args_diff = (3 - static_args) * 4; // format's static args end at index 3, current function's end at static_arg_count. Also * 4 because cells are 4 bytes
 
-    static args;
+    static args, temp_string[256];
+    const string_size = sizeof(temp_string);
+
     args = numargs();
 
     #if !defined OVERRIDE_NATIVE_GAMETEXT
@@ -1021,9 +1023,6 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
         {
             if (args > static_args)
             {
-                static string[256];
-                const string_size = sizeof(string);
-
                 while (--args >= 4)
                 {
                     #emit LCTRL 5
@@ -1037,7 +1036,7 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
 
                 #emit PUSH.S text
                 #emit PUSH.C string_size
-                #emit PUSH.C string
+                #emit PUSH.C temp_string
                 #emit LOAD.S.pri 8
                 #emit ADD.C args_diff
                 #emit PUSH.pri
@@ -1045,13 +1044,15 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
                 #emit LCTRL 5
                 #emit SCTRL 4
 
-                return ORIG_GameTextForPlayer(playerid, string, time, style);
+                return ORIG_GameTextForPlayer(playerid, temp_string, time, style);
             }
             else
             {
                 return ORIG_GameTextForPlayer(playerid, text, time, style);
             }
         }
+    #else
+        #pragma unused temp_string
     #endif
 
     if (gs_GameTextTimer[style][playerid])
@@ -1158,7 +1159,9 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
     const static_args = 3;
     const args_diff = (3 - static_args) * 4; // format's static args end at index 3, current function's end at static_arg_count. Also * 4 because cells are 4 bytes
 
-    static args;
+    static args, temp_string[256];
+    const string_size = sizeof(temp_string);
+
     args = numargs();
 
     #if !defined OVERRIDE_NATIVE_GAMETEXT
@@ -1166,9 +1169,6 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
         {
             if (args > static_args)
             {
-                static string[256];
-                const string_size = sizeof(string);
-
                 while (--args >= 3)
                 {
                     #emit LCTRL 5
@@ -1182,7 +1182,7 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
 
                 #emit PUSH.S text
                 #emit PUSH.C string_size
-                #emit PUSH.C string
+                #emit PUSH.C temp_string
                 #emit LOAD.S.pri 8
                 #emit ADD.C args_diff
                 #emit PUSH.pri
@@ -1190,13 +1190,15 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
                 #emit LCTRL 5
                 #emit SCTRL 4
 
-                return ORIG_GameTextForAll(string, time, style);
+                return ORIG_GameTextForAll(temp_string, time, style);
             }
             else
             {
                 return ORIG_GameTextForAll(text, time, style);
             }
         }
+    #else
+        #pragma unused temp_string
     #endif
 
     if (gs_GameTextTimer[style][MAX_PLAYERS])

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -529,7 +529,7 @@ static stock GameTextEx(playerid)
 
         // Style 16 (Lower Notification Style)
         t = gs_GameTextStyle[16] = TextDrawCreate(28.0, 150.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.416, 1.76);
+        TextDrawLetterSize(t, 0.42, 1.8);
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             TextDrawColour(t, SaveTextDrawColour(t, 0xFFFFFF96));
@@ -548,8 +548,8 @@ static stock GameTextEx(playerid)
         TextDrawTextSize(t, 212.0, 200.0);
 
         // Style 17 (Subtitles Style)
-        t = gs_GameTextStyle[17] = TextDrawCreate(380.0, 345.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.45, 1.95);
+        t = gs_GameTextStyle[17] = TextDrawCreate(320.0, 368.1, EMPTY_STRING);
+        TextDrawLetterSize(t, 0.58, 2.38);
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
@@ -560,11 +560,12 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetOutline(t, 1);
+        TextDrawSetShadow(t, 2);
+        TextDrawSetOutline(t, 0);
         TextDrawFont(t, TEXT_DRAW_FONT:1);
         TextDrawSetProportional(t, true);
         TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 70.0, 448.0);
+        TextDrawTextSize(t, 40.0, 460.0);
     }
     else
     {
@@ -880,7 +881,7 @@ static stock GameTextEx(playerid)
 
         // Style 16 (Lower Notification Style)
         pt = gs_PlayerGameTextStyle[playerid][16] = CreatePlayerTextDraw(playerid, 28.0, 150.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.416, 1.76);
+        PlayerTextDrawLetterSize(playerid, pt, 0.42, 1.8);
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
@@ -899,8 +900,8 @@ static stock GameTextEx(playerid)
         PlayerTextDrawTextSize(playerid, pt, 212.0, 200.0);
 
         // Style 17 (Subtitles Style)
-        pt = gs_PlayerGameTextStyle[playerid][17] = CreatePlayerTextDraw(playerid, 380.0, 345.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.45, 1.95);
+        pt = gs_PlayerGameTextStyle[playerid][17] = CreatePlayerTextDraw(playerid, 320.0, 368.1, EMPTY_STRING);
+        PlayerTextDrawLetterSize(playerid, pt, 0.58, 2.38);
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
@@ -911,11 +912,12 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetOutline(playerid, pt, 1);
+        PlayerTextDrawSetShadow(playerid, pt, 2);
+        PlayerTextDrawSetOutline(playerid, pt, 0);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:1);
         PlayerTextDrawSetProportional(playerid, pt, true);
         PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 70.0, 448.0);
+        PlayerTextDrawTextSize(playerid, pt, 40.0, 460.0);
     }
     return true;
 }

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -471,11 +471,11 @@ static stock GameTextEx(playerid)
         TextDrawLetterSize(t, 0.58, 2.42);
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xDDDDDBFF));
+            TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
             TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
             TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
         #else
-            TextDrawColour(t, 0xDDDDDBFF);
+            TextDrawColour(t, 0xE1E1E1FF);
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
@@ -491,18 +491,18 @@ static stock GameTextEx(playerid)
         TextDrawLetterSize(t, 0.55, 2.2);
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xC3C3C3FF));
+            TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
             TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
             TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
         #else
-            TextDrawColour(t, 0xC3C3C3FF);
+            TextDrawColour(t, 0xE1E1E1FF);
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
         TextDrawSetOutline(t, 2);
         TextDrawFont(t, TEXT_DRAW_FONT:3);
         TextDrawSetProportional(t, false);
-        TextDrawUseBox(t, false);
+        TextDrawUseBox(t, true);
         TextDrawTextSize(t, 400.0, 20.0);
 
         // Style 15 (Notification Popup Style)
@@ -511,12 +511,12 @@ static stock GameTextEx(playerid)
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             TextDrawColour(t, SaveTextDrawColour(t, 0xFFFFFF96));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x000000DD));
+            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x00000000));
+            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000080));
         #else
             TextDrawColour(t, 0xFFFFFF96);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x000000DD);
+            TextDrawBackgroundColour(t, 0x00000000);
+            TextDrawBoxColour(t, 0x00000080);
         #endif
         TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 0);
@@ -531,12 +531,12 @@ static stock GameTextEx(playerid)
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             TextDrawColour(t, SaveTextDrawColour(t, 0xFFFFFF96));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x000000DD));
+            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x00000000));
+            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000080));
         #else
             TextDrawColour(t, 0xFFFFFF96);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x000000DD);
+            TextDrawBackgroundColour(t, 0x00000000);
+            TextDrawBoxColour(t, 0x00000080);
         #endif
         TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 0);
@@ -551,11 +551,11 @@ static stock GameTextEx(playerid)
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000FF));
+            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
             TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
         #else
             TextDrawColour(t, 0xE1E1E1FF);
-            TextDrawBackgroundColour(t, 0x000000FF);
+            TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
         TextDrawSetOutline(t, 1);
@@ -822,11 +822,11 @@ static stock GameTextEx(playerid)
         PlayerTextDrawLetterSize(playerid, pt, 0.58, 2.42);
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xDDDDDBFF));
+            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
             PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
-            PlayerTextDrawColour(playerid, pt, 0xDDDDDBFF);
+            PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
@@ -842,18 +842,18 @@ static stock GameTextEx(playerid)
         PlayerTextDrawLetterSize(playerid, pt, 0.55, 2.2);
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xC3C3C3FF));
+            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
             PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
-            PlayerTextDrawColour(playerid, pt, 0xC3C3C3FF);
+            PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
         PlayerTextDrawSetOutline(playerid, pt, 2);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
         PlayerTextDrawSetProportional(playerid, pt, false);
-        PlayerTextDrawUseBox(playerid, pt, false);
+        PlayerTextDrawUseBox(playerid, pt, true);
         PlayerTextDrawTextSize(playerid, pt, 400.0, 20.0);
 
         // Style 15 (Notification Popup Style)
@@ -862,12 +862,12 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x000000DD));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x00000000));
+            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000080));
         #else
             PlayerTextDrawColour(playerid, pt, 0xFFFFFF96);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x000000DD);
+            PlayerTextDrawBackgroundColour(playerid, pt, 0x00000000);
+            PlayerTextDrawBoxColour(playerid, pt, 0x00000080);
         #endif
         PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 0);
@@ -882,12 +882,12 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x000000DD));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x00000000));
+            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000080));
         #else
             PlayerTextDrawColour(playerid, pt, 0xFFFFFF96);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x000000DD);
+            PlayerTextDrawBackgroundColour(playerid, pt, 0x00000000);
+            PlayerTextDrawBoxColour(playerid, pt, 0x00000080);
         #endif
         PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 0);
@@ -902,11 +902,11 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000FF));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000FF);
+            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
         PlayerTextDrawSetOutline(playerid, pt, 1);

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -1,11 +1,11 @@
 /*
- *   _______  _______  __   __  _______  _______  _______  __   __  _______    _    
- *  |    ___||   _   ||  |_|  ||    ___||_     _||    ___||  |_|  ||_     _| _| |_  
- *  |   | __ |  | |  ||       ||   |___   |   |  |   |___ |       |  |   |  |_   _| 
- *  |   ||  ||  |_|  ||       ||    ___|  |   |  |    ___| |     |   |   |    |_|   
- *  |   |_| ||   _   || ||_|| ||   |___   |   |  |   |___ |   _   |  |   |  
- *  |_______||__| |__||_|   |_||_______|  |___|  |_______||__| |__|  |___|  
- *  
+ *   _______  _______  __   __  _______  _______  _______  __   __  _______    _
+ *  |    ___||   _   ||  |_|  ||    ___||_     _||    ___||  |_|  ||_     _| _| |_
+ *  |   | __ |  | |  ||       ||   |___   |   |  |   |___ |       |  |   |  |_   _|
+ *  |   ||  ||  |_|  ||       ||    ___|  |   |  |    ___| |     |   |   |    |_|
+ *  |   |_| ||   _   || ||_|| ||   |___   |   |  |   |___ |   _   |  |   |
+ *  |_______||__| |__||_|   |_||_______|  |___|  |_______||__| |__|  |___|
+ *
  *  GameText+ created and maintained by itsneufox (v1.2.0)
 
  *  Textdraws originally created by Y_Less for fixes.inc
@@ -63,7 +63,7 @@
     #if !defined TextDrawColour
         #define TextDrawColour TextDrawColor
     #endif
-    
+
 #endif
 
 //! WILD COMPILER appeared! Compiler used WARNINGS about const correctness!
@@ -84,12 +84,12 @@
 #endif
 
 #define     MAX_GAMETEXT_LENGTH     256
-#define     GAMETEXT_LEGACY         6 
+#define     GAMETEXT_LEGACY         6
 #define     GAMETEXT_STYLE_MAX      17
 #define     FADE_INTERVAL           50
 #define     FADE_ALPHA_STEP         0x12
 
-static 
+static
     Text:gs_GameTextStyle[GAMETEXT_STYLE_MAX + 1],
     PlayerText:gs_PlayerGameTextStyle[MAX_PLAYERS][GAMETEXT_STYLE_MAX + 1],
     gs_GameTextTimer[GAMETEXT_STYLE_MAX + 1][MAX_PLAYERS + 1],
@@ -106,7 +106,7 @@ static
 //                          FUNCTION REMAPPING
 //==========================================================================
 
-#if defined _ALS_GameTextForPlayer 
+#if defined _ALS_GameTextForPlayer
     #error _ALS_GameTextForPlayer defined
 #endif
 native BAD_GameTextForPlayer(playerid, const string[], time, style) = GameTextForPlayer;
@@ -125,7 +125,7 @@ native BAD_GameTextForAll(const string[], time, style) = GameTextForAll;
  * SA-MP doesn't provide native getter functions for TextDraw colors
  */
 #if !defined _INC_open_mp
-    static 
+    static
         gs_TextDrawColors[MAX_TEXT_DRAWS],
         gs_TextDrawBGColors[MAX_TEXT_DRAWS],
         gs_TextDrawBoxColors[MAX_TEXT_DRAWS],
@@ -134,57 +134,69 @@ native BAD_GameTextForAll(const string[], time, style) = GameTextForAll;
         gs_PlayerTextDrawBoxColors[MAX_PLAYERS][MAX_PLAYER_TEXT_DRAWS]
     ;
 
-    stock SaveTextDrawColour(Text:text, color) {
+    stock SaveTextDrawColour(Text:text, color)
+    {
         gs_TextDrawColors[_:text] = color;
         return color;
     }
 
-    stock SaveTextDrawBackgroundColour(Text:text, color) {
+    stock SaveTextDrawBackgroundColour(Text:text, color)
+    {
         gs_TextDrawBGColors[_:text] = color;
         return color;
     }
 
-    stock SaveTextDrawBoxColour(Text:text, color) {
+    stock SaveTextDrawBoxColour(Text:text, color)
+    {
         gs_TextDrawBoxColors[_:text] = color;
         return color;
     }
 
-    stock SavePlayerTextDrawColour(playerid, PlayerText:text, color) {
+    stock SavePlayerTextDrawColour(playerid, PlayerText:text, color)
+    {
         gs_PlayerTextDrawColors[playerid][_:text] = color;
         return color;
     }
 
-    stock SavePlayerTextDrawBackgroundColour(playerid, PlayerText:text, color) {
+    stock SavePlayerTextDrawBackgroundColour(playerid, PlayerText:text, color)
+    {
         gs_PlayerTextDrawBGColors[playerid][_:text] = color;
         return color;
     }
 
-    stock SavePlayerTextDrawBoxColour(playerid, PlayerText:text, color) {
+    stock SavePlayerTextDrawBoxColour(playerid, PlayerText:text, color)
+    {
         gs_PlayerTextDrawBoxColors[playerid][_:text] = color;
         return color;
     }
 
-    stock TextDrawGetColour(Text:text) {
+    stock TextDrawGetColour(Text:text)
+    {
         return gs_TextDrawColors[_:text];
     }
 
-    stock TextDrawGetBackgroundColour(Text:text) {
+    stock TextDrawGetBackgroundColour(Text:text)
+    {
         return gs_TextDrawBGColors[_:text];
     }
 
-    stock TextDrawGetBoxColour(Text:text) {
+    stock TextDrawGetBoxColour(Text:text)
+    {
         return gs_TextDrawBoxColors[_:text];
     }
 
-    stock PlayerTextDrawGetColour(playerid, PlayerText:text) {
+    stock PlayerTextDrawGetColour(playerid, PlayerText:text)
+    {
         return gs_PlayerTextDrawColors[playerid][_:text];
     }
 
-    stock PlayerTextDrawGetBackgroundColour(playerid, PlayerText:text) {
+    stock PlayerTextDrawGetBackgroundColour(playerid, PlayerText:text)
+    {
         return gs_PlayerTextDrawBGColors[playerid][_:text];
     }
 
-    stock PlayerTextDrawGetBoxColour(playerid, PlayerText:text) {
+    stock PlayerTextDrawGetBoxColour(playerid, PlayerText:text)
+    {
         return gs_PlayerTextDrawBoxColors[playerid][_:text];
     }
 #endif
@@ -199,15 +211,12 @@ native BAD_GameTextForAll(const string[], time, style) = GameTextForAll;
  */
 static stock GameTextEx(playerid)
 {
-    new
-        EMPTY_STRING[2] = " "
-    ;
-    
+    new EMPTY_STRING[2] = " ";
+
     if (playerid == INVALID_PLAYER_ID)
     {
-        new 
-            Text:t
-        ;
+        new Text:t;
+
          #if defined OVERRIDE_NATIVE_GAMETEXT
             // Native style 0
             t = gs_GameTextStyle[0] = TextDrawCreate(320.0, 214.0, EMPTY_STRING);
@@ -222,7 +231,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 2);
             TextDrawFont(t, TEXT_DRAW_FONT:3);
             TextDrawSetProportional(t, true);
@@ -242,7 +250,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 2);
             TextDrawFont(t, TEXT_DRAW_FONT:3);
             TextDrawSetProportional(t, true);
@@ -262,7 +269,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 3);
             TextDrawFont(t, TEXT_DRAW_FONT:0);
             TextDrawSetProportional(t, true);
@@ -282,7 +288,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 2);
             TextDrawFont(t, TEXT_DRAW_FONT:2);
             TextDrawSetProportional(t, true);
@@ -302,7 +307,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 2);
             TextDrawFont(t, TEXT_DRAW_FONT:2);
             TextDrawSetProportional(t, true);
@@ -322,7 +326,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 2);
             TextDrawFont(t, TEXT_DRAW_FONT:2);
             TextDrawSetProportional(t, true);
@@ -342,7 +345,6 @@ static stock GameTextEx(playerid)
                 TextDrawBackgroundColour(t, 0x000000AA);
                 TextDrawBoxColour(t, 0x00000000);
             #endif
-            TextDrawSetShadow(t, 0);
             TextDrawSetOutline(t, 2);
             TextDrawFont(t, TEXT_DRAW_FONT:3);
             TextDrawSetProportional(t, true);
@@ -363,7 +365,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 2);
         TextDrawFont(t, TEXT_DRAW_FONT:2);
         TextDrawSetProportional(t, true);
@@ -383,7 +384,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 2);
         TextDrawFont(t, TEXT_DRAW_FONT:0);
         TextDrawSetProportional(t, true);
@@ -403,7 +403,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 1);
         TextDrawFont(t, TEXT_DRAW_FONT:2);
         TextDrawSetProportional(t, true);
@@ -423,7 +422,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 1);
         TextDrawFont(t, TEXT_DRAW_FONT:2);
         TextDrawSetProportional(t, true);
@@ -443,7 +441,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 2);
         TextDrawFont(t, TEXT_DRAW_FONT:3);
         TextDrawSetProportional(t, false);
@@ -463,7 +460,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 2);
         TextDrawFont(t, TEXT_DRAW_FONT:3);
         TextDrawSetProportional(t, false);
@@ -503,7 +499,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000AA);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 2);
         TextDrawFont(t, TEXT_DRAW_FONT:3);
         TextDrawSetProportional(t, false);
@@ -532,7 +527,7 @@ static stock GameTextEx(playerid)
 
         // Style 16 (Lower Notification Style)
         t = gs_GameTextStyle[16] = TextDrawCreate(28.0, 150.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.416, 1.760);
+        TextDrawLetterSize(t, 0.416, 1.76);
         TextDrawAlignment(t, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             TextDrawColour(t, SaveTextDrawColour(t, 0xFFFFFF96));
@@ -563,7 +558,6 @@ static stock GameTextEx(playerid)
             TextDrawBackgroundColour(t, 0x000000FF);
             TextDrawBoxColour(t, 0x00000000);
         #endif
-        TextDrawSetShadow(t, 0);
         TextDrawSetOutline(t, 1);
         TextDrawFont(t, TEXT_DRAW_FONT:1);
         TextDrawSetProportional(t, true);
@@ -588,7 +582,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 2);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -608,7 +601,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 2);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -628,7 +620,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 3);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:0);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -648,7 +639,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 2);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -668,7 +658,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 2);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -688,7 +677,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 2);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -708,7 +696,6 @@ static stock GameTextEx(playerid)
                 PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
                 PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
             #endif
-            PlayerTextDrawSetShadow(playerid, pt, 0);
             PlayerTextDrawSetOutline(playerid, pt, 2);
             PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
             PlayerTextDrawSetProportional(playerid, pt, true);
@@ -729,7 +716,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 2);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
         PlayerTextDrawSetProportional(playerid, pt, true);
@@ -749,7 +735,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 2);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:0);
         PlayerTextDrawSetProportional(playerid, pt, true);
@@ -769,7 +754,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 1);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
         PlayerTextDrawSetProportional(playerid, pt, true);
@@ -789,7 +773,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 1);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
         PlayerTextDrawSetProportional(playerid, pt, true);
@@ -809,7 +792,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 2);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
         PlayerTextDrawSetProportional(playerid, pt, false);
@@ -829,7 +811,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 2);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
         PlayerTextDrawSetProportional(playerid, pt, false);
@@ -869,7 +850,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 2);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
         PlayerTextDrawSetProportional(playerid, pt, false);
@@ -898,7 +878,7 @@ static stock GameTextEx(playerid)
 
         // Style 16 (Lower Notification Style)
         pt = gs_PlayerGameTextStyle[playerid][16] = CreatePlayerTextDraw(playerid, 28.0, 150.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.416, 1.760);
+        PlayerTextDrawLetterSize(playerid, pt, 0.416, 1.76);
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
@@ -929,7 +909,6 @@ static stock GameTextEx(playerid)
             PlayerTextDrawBackgroundColour(playerid, pt, 0x000000FF);
             PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
         #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
         PlayerTextDrawSetOutline(playerid, pt, 1);
         PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:1);
         PlayerTextDrawSetProportional(playerid, pt, true);
@@ -947,7 +926,7 @@ static stock GameTextEx(playerid)
 forward OnHideGameText(playerid, styleid);
 public OnHideGameText(playerid, styleid)
 {
-    if (styleid == 14 || styleid == 9 || styleid == 10)
+    if (9 <= style <= 10 || style == 14)
     {
         if (playerid == MAX_PLAYERS)
         {
@@ -957,7 +936,7 @@ public OnHideGameText(playerid, styleid)
         else
         {
             PlayerTextDrawHide(playerid, gs_PlayerGameTextStyle[playerid][styleid]);
-            gs_GameTextTimer[styleid][playerid] = 0; 
+            gs_GameTextTimer[styleid][playerid] = 0;
         }
         return 1;
     }
@@ -966,9 +945,9 @@ public OnHideGameText(playerid, styleid)
     {
         if (playerid == MAX_PLAYERS)
         {
-            gs_GameTextOriginalColor[styleid][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[styleid]); 
-            gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[styleid]); 
-            gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] = TextDrawGetBoxColour(gs_GameTextStyle[styleid]); 
+            gs_GameTextOriginalColor[styleid][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[styleid]);
+            gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[styleid]);
+            gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] = TextDrawGetBoxColour(gs_GameTextStyle[styleid]);
         }
         else
         {
@@ -979,7 +958,7 @@ public OnHideGameText(playerid, styleid)
         gs_GameTextIsFadingOut[styleid][playerid] = true;
     }
 
-    OnFadeOutGameText(playerid, styleid, 
+    OnFadeOutGameText(playerid, styleid,
         gs_GameTextOriginalColor[styleid][playerid] & 0xFF,
         gs_GameTextOriginalBGColor[styleid][playerid] & 0xFF,
         gs_GameTextOriginalBoxColor[styleid][playerid] & 0xFF
@@ -1016,9 +995,9 @@ static stock OnDestroyGameText(playerid)
  * @param playerid - Target player
  * @param text - Text to display
  * @param time - Duration in milliseconds (0 for permanent)
- * @param style - Style ID (0-6 for native, 7-15 for extended)
+ * @param style - Style ID (0-6 for native, 7-17 for extended)
  */
-stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
+stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
 {
     if (!IsPlayerConnected(playerid)) return false;
 
@@ -1034,7 +1013,7 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
 
     static args;
     args = numargs();
-    
+
     #if !defined OVERRIDE_NATIVE_GAMETEXT
         if (style <= GAMETEXT_LEGACY)
         {
@@ -1063,7 +1042,7 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
                 #emit SYSREQ.C format
                 #emit LCTRL 5
                 #emit SCTRL 4
-                
+
                 return BAD_GameTextForPlayer(playerid, string, time, style);
             }
             else
@@ -1072,29 +1051,29 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
             }
         }
     #endif
-    
+
     if (gs_GameTextTimer[style][playerid])
     {
         KillTimer(gs_GameTextTimer[style][playerid]);
         gs_GameTextTimer[style][playerid] = 0;
     }
-    
+
     if (gs_GameTextFadeInTimer[style][playerid])
     {
         KillTimer(gs_GameTextFadeInTimer[style][playerid]);
         gs_GameTextFadeInTimer[style][playerid] = 0;
     }
-    
+
     if (gs_GameTextFadeOutTimer[style][playerid])
     {
         KillTimer(gs_GameTextFadeOutTimer[style][playerid]);
         gs_GameTextFadeOutTimer[style][playerid] = 0;
     }
-    
+
     gs_GameTextIsFadingOut[style][playerid] = false;
     gs_GameTextIsFadingIn[style][playerid] = false;
-    
-    if (style != 14 && style != 9 && style != 10)
+
+    if (!(9 <= styleid <= 10) && styleid != 14)
     {
         gs_GameTextOriginalColor[style][playerid] = PlayerTextDrawGetColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
         gs_GameTextOriginalBGColor[style][playerid] = PlayerTextDrawGetBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
@@ -1126,7 +1105,7 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
         #emit SYSREQ.C format
         #emit LCTRL 5
         #emit SCTRL 4
-        
+
         PlayerTextDrawSetString(playerid, gs_PlayerGameTextStyle[playerid][style], string);
     }
     else
@@ -1140,7 +1119,7 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
         #endif
     }
 
-    if (style == 14 || style == 9 || style == 10)
+    if (9 <= style <= 10 || style == 14)
     {
         PlayerTextDrawShow(playerid, gs_PlayerGameTextStyle[playerid][style]);
     }
@@ -1149,12 +1128,12 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
         gs_GameTextIsFadingIn[style][playerid] = true;
         OnFadeInGameText(playerid, style, 0, 0, 0);
     }
-    
+
     if (time > 0)
     {
         gs_GameTextTimer[style][playerid] = SetTimerEx("OnHideGameText", time, false, "dd", playerid, style);
     }
-    
+
     return true;
 }
 
@@ -1163,9 +1142,9 @@ stock FIXES_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:..
  * Enhanced GameTextForAll with support for extended styles
  * @param text - Text to display
  * @param time - Duration in milliseconds (0 for permanent)
- * @param style - Style ID (0-6 for native, 7-15 for extended)
+ * @param style - Style ID (0-6 for native, 7-17 for extended)
  */
-stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
+stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
 {
     #if defined OVERRIDE_NATIVE_GAMETEXT
         if (!(GAMETEXT_STYLE_MIN <= style <= GAMETEXT_STYLE_MAX)) return false;
@@ -1179,7 +1158,7 @@ stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
 
     static args;
     args = numargs();
-    
+
     #if !defined OVERRIDE_NATIVE_GAMETEXT
         if (style <= GAMETEXT_LEGACY)
         {
@@ -1208,7 +1187,7 @@ stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
                 #emit SYSREQ.C format
                 #emit LCTRL 5
                 #emit SCTRL 4
-                
+
                 return BAD_GameTextForAll(string, time, style);
             }
             else
@@ -1217,29 +1196,29 @@ stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
             }
         }
     #endif
-    
+
     if (gs_GameTextTimer[style][MAX_PLAYERS])
     {
         KillTimer(gs_GameTextTimer[style][MAX_PLAYERS]);
         gs_GameTextTimer[style][MAX_PLAYERS] = 0;
     }
-    
+
     if (gs_GameTextFadeInTimer[style][MAX_PLAYERS])
     {
         KillTimer(gs_GameTextFadeInTimer[style][MAX_PLAYERS]);
         gs_GameTextFadeInTimer[style][MAX_PLAYERS] = 0;
     }
-    
+
     if (gs_GameTextFadeOutTimer[style][MAX_PLAYERS])
     {
         KillTimer(gs_GameTextFadeOutTimer[style][MAX_PLAYERS]);
         gs_GameTextFadeOutTimer[style][MAX_PLAYERS] = 0;
     }
-    
+
     gs_GameTextIsFadingOut[style][MAX_PLAYERS] = false;
     gs_GameTextIsFadingIn[style][MAX_PLAYERS] = false;
-    
-    if (style != 14 && style != 9 && style != 10)
+
+    if (!(9 <= styleid <= 10) && styleid != 14)
     {
         gs_GameTextOriginalColor[style][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[style]);
         gs_GameTextOriginalBGColor[style][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[style]);
@@ -1271,7 +1250,7 @@ stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
         #emit SYSREQ.C format
         #emit LCTRL 5
         #emit SCTRL 4
-        
+
         TextDrawSetString(gs_GameTextStyle[style], string);
     }
     else
@@ -1285,7 +1264,7 @@ stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
         #endif
     }
 
-    if (style == 14 || style == 9 || style == 10)
+    if (9 <= style <= 10 || style == 14)
     {
         TextDrawShowForAll(gs_GameTextStyle[style]);
     }
@@ -1294,12 +1273,12 @@ stock FIXES_GameTextForAll(const text[], time, style, {Float, _}:...)
         gs_GameTextIsFadingIn[style][MAX_PLAYERS] = true;
         OnFadeInGameText(MAX_PLAYERS, style, 0, 0, 0);
     }
-    
+
     if (time > 0)
     {
         gs_GameTextTimer[style][MAX_PLAYERS] = SetTimerEx("OnHideGameText", time, false, "dd", MAX_PLAYERS, style);
     }
-    
+
     return true;
 }
 
@@ -1315,35 +1294,35 @@ forward OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
 public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, boxColourAlpha)
 {
     new targetAlpha = (gs_GameTextOriginalColor[styleid][playerid] & 0xFF);
-    
+
     if (colourAlpha < targetAlpha)
     {
         colourAlpha += clamp(targetAlpha / FADE_ALPHA_STEP, 1, targetAlpha - colourAlpha);
     }
-    
+
     targetAlpha = (gs_GameTextOriginalBGColor[styleid][playerid] & 0xFF);
     if (backgroundColourAlpha < targetAlpha)
     {
         backgroundColourAlpha += clamp(targetAlpha / FADE_ALPHA_STEP, 1, targetAlpha - backgroundColourAlpha);
     }
-    
+
     targetAlpha = (gs_GameTextOriginalBoxColor[styleid][playerid] & 0xFF);
     if (boxColourAlpha < targetAlpha)
     {
         boxColourAlpha += clamp(targetAlpha / FADE_ALPHA_STEP, 1, targetAlpha - boxColourAlpha);
     }
 
-    if (colourAlpha < (gs_GameTextOriginalColor[styleid][playerid] & 0xFF) || 
-        backgroundColourAlpha < (gs_GameTextOriginalBGColor[styleid][playerid] & 0xFF) || 
+    if (colourAlpha < (gs_GameTextOriginalColor[styleid][playerid] & 0xFF) ||
+        backgroundColourAlpha < (gs_GameTextOriginalBGColor[styleid][playerid] & 0xFF) ||
         boxColourAlpha < (gs_GameTextOriginalBoxColor[styleid][playerid] & 0xFF))
     {
         if (playerid == MAX_PLAYERS)
         {
-            TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha); 
-            TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha); 
-            if (styleid != 14 && styleid != 9 && styleid != 10)
+            TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);
+            TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha);
+            if (!(9 <= styleid <= 10) && styleid != 14)
             {
-                TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);  
+                TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);
             }
             TextDrawShowForAll(gs_GameTextStyle[styleid]);
         }
@@ -1351,7 +1330,7 @@ public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, b
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | colourAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | backgroundColourAlpha);
-            if (styleid != 14 && styleid != 9 && styleid != 10)
+            if (!(9 <= styleid <= 10) && styleid != 14)
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | boxColourAlpha);
             }
@@ -1365,7 +1344,7 @@ public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, b
         gs_GameTextIsFadingIn[styleid][playerid] = false;
         gs_GameTextFadeInTimer[styleid][playerid] = 0;
     }
-    return true;
+    return 1;
 }
 
 /*
@@ -1396,11 +1375,11 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
     {
         if (playerid == MAX_PLAYERS)
         {
-            TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);  
-            TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha); 
-            if (styleid != 14 && styleid != 9 && styleid != 10)
+            TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);
+            TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha);
+            if (!(9 <= styleid <= 10) && styleid != 14)
             {
-                TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha); 
+                TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);
             }
             TextDrawShowForAll(gs_GameTextStyle[styleid]);
         }
@@ -1408,7 +1387,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | colourAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | backgroundColourAlpha);
-            if (styleid != 14 && styleid != 9 && styleid != 10)
+            if (!(9 <= styleid <= 10) && styleid != 14)
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | boxColourAlpha);
             }
@@ -1419,17 +1398,19 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
     }
     else
     {
-        new origColorAlpha = gs_GameTextOriginalColor[styleid][playerid] & 0xFF;
-        new origBGAlpha = gs_GameTextOriginalBGColor[styleid][playerid] & 0xFF;
-        new origBoxAlpha = gs_GameTextOriginalBoxColor[styleid][playerid] & 0xFF;
+        new
+            origColorAlpha = (gs_GameTextOriginalColor[styleid][playerid] & 0xFF),
+            origBGAlpha = (gs_GameTextOriginalBGColor[styleid][playerid] & 0xFF),
+            origBoxAlpha = (gs_GameTextOriginalBoxColor[styleid][playerid] & 0xFF)
+        ;
 
         if (playerid == MAX_PLAYERS)
         {
-            TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | origColorAlpha); 
-            TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | origBGAlpha); 
-            if (styleid != 14 && styleid != 9 && styleid != 10)
+            TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | origColorAlpha);
+            TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | origBGAlpha);
+            if (!(9 <= styleid <= 10) && styleid != 14)
             {
-                TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | origBoxAlpha); 
+                TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | origBoxAlpha);
             }
             TextDrawHideForAll(gs_GameTextStyle[styleid]);
         }
@@ -1437,7 +1418,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | origColorAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | origBGAlpha);
-            if (styleid != 14 && styleid != 9 && styleid != 10)
+            if (!(9 <= styleid <= 10) && styleid != 14)
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | origBoxAlpha);
             }
@@ -1447,7 +1428,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         gs_GameTextIsFadingOut[styleid][playerid] = false;
         gs_GameTextFadeOutTimer[styleid][playerid] = 0;
     }
-    return true;
+    return 1;
 }
 
 //==========================================================================
@@ -1455,19 +1436,19 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
 //==========================================================================
 
 #define _ALS_GameTextForPlayer
-#define GameTextForPlayer FIXES_GameTextForPlayer
+#define GameTextForPlayer GTP_GameTextForPlayer
 
-#define _ALS_GameTextForAll  
-#define GameTextForAll FIXES_GameTextForAll
+#define _ALS_GameTextForAll
+#define GameTextForAll GTP_GameTextForAll
 
 public OnPlayerConnect(playerid)
 {
     GameTextEx(playerid);
-    
+
     #if defined GTP_OnPlayerConnect
         return GTP_OnPlayerConnect(playerid);
     #else
-        return true;
+        return 1;
     #endif
 }
 #if defined _ALS_OnPlayerConnect
@@ -1497,13 +1478,13 @@ public OnPlayerDisconnect(playerid, reason)
         gs_GameTextIsFadingOut[style][playerid] = false;
         gs_GameTextIsFadingIn[style][playerid] = false;
     }
-    
+
     OnDestroyGameText(playerid);
-    
+
     #if defined GTP_OnPlayerDisconnect
         return GTP_OnPlayerDisconnect(playerid, reason);
     #else
-        return true;
+        return 1;
     #endif
 }
 #if defined _ALS_OnPlayerDisconnect
@@ -1519,11 +1500,11 @@ public OnPlayerDisconnect(playerid, reason)
 public OnGameModeInit()
 {
     GameTextEx(INVALID_PLAYER_ID);
-    
+
     #if defined GTP_OnGameModeInit
         return GTP_OnGameModeInit();
     #else
-        return true;
+        return 1;
     #endif
 }
 #if defined _ALS_OnGameModeInit
@@ -1539,11 +1520,11 @@ public OnGameModeInit()
 public OnGameModeExit()
 {
     OnDestroyGameText(INVALID_PLAYER_ID);
-    
+
     #if defined GTP_OnGameModeExit
         return GTP_OnGameModeExit();
     #else
-        return true;
+        return 1;
     #endif
 }
 #if defined _ALS_OnGameModeExit

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -67,9 +67,11 @@
 #endif
 
 //! WILD COMPILER appeared! Compiler used WARNINGS about const correctness!
-#if !defined _INC_open_mp
-    #pragma warning push
-    #pragma warning disable 239
+#if !defined _INC_open_mp && defined __PawnBuild
+    #if __PawnBuild > 4
+        #pragma warning push
+        #pragma warning disable 239
+    #endif
 #endif
 //! Developer used PRAGMA! It's super effective, compiler's warning level fell sharply!
 
@@ -158,7 +160,7 @@ native ORIG_GameTextForAll(const string[], time, style) = GameTextForAll;
         return color;
     }
 
-    stock SavePlayerTextDrawBackgroundColour(playerid, PlayerText:text, color)
+    stock SavePlayerTextDrawBackgroundCol(playerid, PlayerText:text, color)
     {
         gs_PlayerTextDrawBGColors[playerid][_:text] = color;
         return color;
@@ -190,7 +192,7 @@ native ORIG_GameTextForAll(const string[], time, style) = GameTextForAll;
         return gs_PlayerTextDrawColors[playerid][_:text];
     }
 
-    stock PlayerTextDrawGetBackgroundColour(playerid, PlayerText:text)
+    stock PlayerTextDrawGetBackgroundCol(playerid, PlayerText:text)
     {
         return gs_PlayerTextDrawBGColors[playerid][_:text];
     }
@@ -575,7 +577,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0x906210FF);
@@ -594,7 +596,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0x906210FF);
@@ -613,7 +615,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
@@ -632,7 +634,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0x906210FF);
@@ -651,7 +653,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0x906210FF);
@@ -670,7 +672,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
@@ -689,7 +691,7 @@ static stock GameTextEx(playerid)
             PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
             #if !defined _INC_open_mp
                 PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xACCBF1FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
                 PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
             #else
                 PlayerTextDrawColour(playerid, pt, 0xACCBF1FF);
@@ -709,7 +711,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x36682CFF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0x36682CFF);
@@ -728,7 +730,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xACCBF1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0xACCBF1FF);
@@ -747,7 +749,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0x906210FF);
@@ -766,7 +768,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x969696FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0x969696FF);
@@ -785,7 +787,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x36682CFF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0x36682CFF);
@@ -804,7 +806,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xB4191DFF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0xB4191DFF);
@@ -823,7 +825,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
@@ -843,7 +845,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
@@ -862,7 +864,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x00000000));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x00000000));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000080));
         #else
             PlayerTextDrawColour(playerid, pt, 0xFFFFFF96);
@@ -882,7 +884,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x00000000));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x00000000));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000080));
         #else
             PlayerTextDrawColour(playerid, pt, 0xFFFFFF96);
@@ -902,7 +904,7 @@ static stock GameTextEx(playerid)
         PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
         #if !defined _INC_open_mp
             PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA));
+            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
             PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
         #else
             PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
@@ -926,7 +928,7 @@ static stock GameTextEx(playerid)
 forward OnHideGameText(playerid, styleid);
 public OnHideGameText(playerid, styleid)
 {
-    if (9 <= style <= 10 || style == 14)
+    if (9 <= styleid <= 10 || styleid == 14)
     {
         if (playerid == MAX_PLAYERS)
         {
@@ -1073,10 +1075,10 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     gs_GameTextIsFadingOut[style][playerid] = false;
     gs_GameTextIsFadingIn[style][playerid] = false;
 
-    if (!(9 <= styleid <= 10) && styleid != 14)
+    if (!(9 <= style <= 10) && style != 14)
     {
         gs_GameTextOriginalColor[style][playerid] = PlayerTextDrawGetColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
-        gs_GameTextOriginalBGColor[style][playerid] = PlayerTextDrawGetBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
+        gs_GameTextOriginalBGColor[style][playerid] = PlayerTextDrawGetBackgroundCol(playerid, gs_PlayerGameTextStyle[playerid][style]);
         gs_GameTextOriginalBoxColor[style][playerid] = PlayerTextDrawGetBoxColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
     }
 
@@ -1218,7 +1220,7 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
     gs_GameTextIsFadingOut[style][MAX_PLAYERS] = false;
     gs_GameTextIsFadingIn[style][MAX_PLAYERS] = false;
 
-    if (!(9 <= styleid <= 10) && styleid != 14)
+    if (!(9 <= style <= 10) && style != 14)
     {
         gs_GameTextOriginalColor[style][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[style]);
         gs_GameTextOriginalBGColor[style][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[style]);
@@ -1538,7 +1540,9 @@ public OnGameModeExit()
 #endif
 
 //! Developer's PRAGMA wore off!
-#if !defined _INC_open_mp
-    #pragma warning pop
+#if !defined _INC_open_mp && defined __PawnBuild
+    #if __PawnBuild > 4
+        #pragma warning pop
+    #endif
 #endif
 //! Compiler awakens! Its power is restored to its previous state!


### PR DESCRIPTION
1. General format fixes: tweaked redundant spacing, made braces style to be consistent across the project, as well as consistent return values in default callbacks
2. Make it actually work on default SA-MP compiler, as before this it used unknown `#pragma warning` and function names more than 31 char. Please note that I've changed `PlayerTextDrawGetBackgroundColour` to `PlayerTextDrawGetBackgroundCol` **everywhere**, even when using omp-stdlib, but it shouldn't be an issue as [both of those](https://github.com/openmultiplayer/omp-stdlib/blob/master/omp_textdraw.inc#L1465-L1477) native names are declared in open.mp libs
3. Some of the local variables (`string`) were given a bit more unique names to prevent name shadowing under different circumstances on normal SA-MP compiler; main problems were with defined `OVERRIDE_NATIVE_GAMETEXT`
4. Some checks which were using `this == 1 || this == 2` pattern were improved to `1 <= this <= 2`, consider it a micro-optimization
5. Renamed `FIXES_` hook prefix into `GTP_` to be in line with other hook prefixes of this library
6. Renamed `BAD_` prefix into `ORIG_` (I still don't understand why fixes.inc has such dumb prefix names)
7. Renamed `GAMETEXT_STYLE_MIN`/`GAMETEXT_STYLE_MAX` into `MIN_GAMETEXT_STYLE`/`MAX_GAMETEXT_STYLE` to follow the correct grammar. Since it's not exposed into the user script, no extra changes are needed outside the lib after this update
8. Removed setting the textdraw shadow explicitly when there's already set an outline (if there was an outline set, shadow won't be ever displayed anyway)
9. Styles 3-6, 11-13 and 17 were excluded from applying fading effect because they don't have it in singleplayer
10. Stunt bonus (style 13) and clock (style 14) was made with the same color as in subtitles (style 17), it's `0xE1E1E1FF`; fixes.inc has it wrong. Proof: [one](https://github.com/multitheftauto/mtasa-blue/blob/master/Client/game_sa/CHudSA.cpp#L45) -> [two](https://github.com/multitheftauto/mtasa-blue/blob/master/Client/game_sa/CHudSA.cpp#L407-L408)
11. Style 15 and 16 (notifications) have too dark box, it's clearly seen when comparing to singleplayer help messages (and also can be compared with SA-MP menus). Alpha value `0x80` (128) looks much more correct than the current `0xDD` (221)
12. Tweaked another couple of issues from fixes.inc gametexts implementation: style 14 has box disabled (yes it's anyway transparent, but it needs to be enabled for right positioning in case with multi-line text), and style 15/16 has background color `0x000000AA` instead of `0x00000000`
13. Tweaked letter size of custom "lower" notification (style 16), now it's more predictable on different resolutions as it uses round values
14. Corrected position, size and outline of subtitles (style 17): now it looks like it should [in the original GTA SA](https://youtu.be/ZvPem5XYBrU?si=alx-jjf_vAMIRIzq&t=76). Previous concept were taken from some weird game version where both subtitles and objectives (it's what implemented here as "stunt bonus" style) have been too small and had outline instead of shadow. Since the stunt style is commonly accepted to look with shadow not outline, the same finally applied here for subtitles as well