### PR TITLE
One more tweak for omp-stdlib

### DIFF
--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -63,7 +63,10 @@
     #if !defined TextDrawColour
         #define TextDrawColour TextDrawColor
     #endif
-
+#else // defined _INC_open_mp
+    #if __namemax > 31
+        #define PlayerTextDrawGetBackgroundCol PlayerTextDrawGetBackgroundColour
+    #endif
 #endif
 
 //! WILD COMPILER appeared! Compiler used WARNINGS about const correctness!


### PR DESCRIPTION
I thought how I can improve the thing from the latest PR, namely this one:
> Please note that I've changed `PlayerTextDrawGetBackgroundColour` to `PlayerTextDrawGetBackgroundCol` **everywhere**, even when using omp-stdlib, but it shouldn't be an issue as [both of those](https://github.com/openmultiplayer/omp-stdlib/blob/master/omp_textdraw.inc#L1465-L1477) native names are declared in open.mp libs

and after all decided to redefine it to `PlayerTextDrawGetBackgroundColour` in case if the user has both omp libs with omp compiler (thus it's clear that the name limit is more than 31 char and he can afford longer names). If he doesn't use `SAMP_COMPAT`, he might get a deprecation warning on shorten version of `PlayerTextDrawGetBackgroundCol`. So now right in this case he won't get this and compilation will be good