### PR TITLE
Fader improvements, pawn.json and tests

### DIFF
--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -91,6 +91,7 @@
 #define     MAX_GAMETEXT_LENGTH     256
 #define     GAMETEXT_LEGACY         6
 #define     MAX_GAMETEXT_STYLE      17
+
 #define     FADE_INTERVAL           50
 #define     FADE_ALPHA_STEP         0x12
 
@@ -1127,7 +1128,7 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
         #endif
     }
 
-    if (3 <= style <= 6 || 9 <= style <= 14 || style == 17)
+    if (style == 1 || 3 <= style <= 6 || 9 <= style <= 17)
     {
         PlayerTextDrawShow(playerid, gs_PlayerGameTextStyle[playerid][style]);
     }
@@ -1273,7 +1274,7 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
         #endif
     }
 
-    if (3 <= style <= 6 || 9 <= style <= 14 || style == 17)
+    if (style == 1 || 3 <= style <= 6 || 9 <= style <= 17)
     {
         TextDrawShowForAll(gs_GameTextStyle[style]);
     }

--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -28,7 +28,7 @@
 #define _INC_gametext_plus
 
 #if defined _INC_SAMP_Community_fixes
-    #error "Incompatibility detected: 'fixes.inc' is deprecated in open.mp. Please remove it from your project. All GameText functionalities are now provided by GameText+ include."
+    #error "Incompatibility detected: 'fixes.inc'. Please remove it from your project. All GameText functionalities are now provided by GameText+ include."
 #endif
 
 #if !defined _INC_open_mp

--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,10 @@
+{
+	"user": "itsneufox",
+	"repo": "GameText-Plus",
+	"entry": "testing/omp/omp_test.pwn",
+	"output": "testing/omp/omp_test.amx",
+	"dependencies": [
+		"openmultiplayer/omp-stdlib"
+	],
+	"include_path": "include"
+}

--- a/testing/omp/omp_test.pwn
+++ b/testing/omp/omp_test.pwn
@@ -1,13 +1,13 @@
 /*
- *   _______  _______  __   __  _______  _______  _______  __   __  _______    _    
- *  |    ___||   _   ||  |_|  ||    ___||_     _||    ___||  |_|  ||_     _| _| |_  
- *  |   | __ |  | |  ||       ||   |___   |   |  |   |___ |       |  |   |  |_   _| 
- *  |   ||  ||  |_|  ||       ||    ___|  |   |  |    ___| |     |   |   |    |_|   
- *  |   |_| ||   _   || ||_|| ||   |___   |   |  |   |___ |   _   |  |   |  
- *  |_______||__| |__||_|   |_||_______|  |___|  |_______||__| |__|  |___|  
- *  
+ *   _______  _______  __   __  _______  _______  _______  __   __  _______    _
+ *  |    ___||   _   ||  |_|  ||    ___||_     _||    ___||  |_|  ||_     _| _| |_
+ *  |   | __ |  | |  ||       ||   |___   |   |  |   |___ |       |  |   |  |_   _|
+ *  |   ||  ||  |_|  ||       ||    ___|  |   |  |    ___| |     |   |   |    |_|
+ *  |   |_| ||   _   || ||_|| ||   |___   |   |  |   |___ |   _   |  |   |
+ *  |_______||__| |__||_|   |_||_______|  |___|  |_______||__| |__|  |___|
+ *
  *  GameText+ test gamemode created and maintained by itsneufox (v1.0.1)
- * 
+ *
  * This gamemode demonstrates all available gametext styles from the GameText+ include.
  * It provides an interactive way to test different text effects, styles and formatting options.
  */
@@ -23,12 +23,11 @@
 */
 #define OVERRIDE_NATIVE_GAMETEXT
 
-
 #include <gametext_plus>
 
 main()
 {
-	printf(" ");
+    printf(" ");
     printf("    _______  _______  __   __  _______  _______  _______  __   __  _______    _   ");
     printf("   |    ___||   _   ||  |_|  ||    ___||_     _||    ___||  |_|  ||_     _| _| |_ ");
     printf("   |   | __ |  |_|  ||       ||   |___   |   |  |   |___ |       |  |   |  |_   _|");
@@ -41,7 +40,7 @@ main()
 
 #define DIALOG_TEST_MENU 1000
 
-new 
+new
     gCurrentStyle[MAX_PLAYERS],
     gTestActive[MAX_PLAYERS],
     bool:gPlayerShowingStyles[MAX_PLAYERS],
@@ -50,32 +49,32 @@ new
 
 public OnGameModeInit()
 {
-	SetGameModeText("GameText+");
+    SetGameModeText("GameText+");
 
-	return true;
+    return true;
 }
 
 public OnPlayerConnect(playerid)
 {
-	gCurrentStyle[playerid] = 0;
+    gCurrentStyle[playerid] = 0;
     gTestActive[playerid] = 0;
     gPlayerShowingStyles[playerid] = false;
     gTestType[playerid] = 0;
-   
+
     SendClientMessage(playerid, -1, "Welcome! Use these commands to test GameText styles:");
     SendClientMessage(playerid, -1, "  {FFFF00}/test{FFFFFF} - Open the GameText test menu");
     SendClientMessage(playerid, -1, "  {FFFF00}/stop{FFFFFF} - Stop the active test");
 
     TogglePlayerSpectating(playerid, true);
 
-	return true;
+    return true;
 }
 
 public OnPlayerDisconnect(playerid, reason)
 {
-	gPlayerShowingStyles[playerid] = false;
+    gPlayerShowingStyles[playerid] = false;
 
-	return true;
+    return true;
 }
 
 public OnPlayerCommandText(playerid, cmdtext[])
@@ -87,11 +86,11 @@ public OnPlayerCommandText(playerid, cmdtext[])
             GameTextForPlayer(playerid, "~r~Test already running!", 3000, 6);
             return true;
         }
-        
+
         ShowTestDialog(playerid);
         return true;
     }
-    
+
     if (!strcmp(cmdtext, "/stop", true))
     {
         if (!gTestActive[playerid])
@@ -99,14 +98,14 @@ public OnPlayerCommandText(playerid, cmdtext[])
             GameTextForPlayer(playerid, "~r~No test running!", 3000, 6);
             return true;
         }
-        
+
         gTestActive[playerid] = 0;
         gPlayerShowingStyles[playerid] = false;
         KillTimer(gTestActive[playerid]);
         GameTextForPlayer(playerid, "~y~Test Stopped", 3000, 6);
         return true;
     }
-    
+
     return false;
 }
 
@@ -117,20 +116,20 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
         case DIALOG_TEST_MENU:
         {
             if (!response) return true;
-            
+
             gTestType[playerid] = listitem;
             gCurrentStyle[playerid] = 0;
             gPlayerShowingStyles[playerid] = true;
-            
+
             new string[128];
-            format(string, sizeof(string), "Starting GameText test with %s...", 
-                (listitem == 0) ? "normal GameTextForPlayer" : 
-                (listitem == 1) ? "formatted GameTextForPlayer" : 
-                (listitem == 2) ? "normal GameTextForAll" : 
+            format(string, sizeof(string), "Starting GameText test with %s...",
+                (listitem == 0) ? "normal GameTextForPlayer" :
+                (listitem == 1) ? "formatted GameTextForPlayer" :
+                (listitem == 2) ? "normal GameTextForAll" :
                 "formatted GameTextForAll");
-                
+
             SendClientMessage(playerid, -1, string);
-            
+
             StartStyleTest(playerid);
             return true;
         }
@@ -140,8 +139,8 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 
 ShowTestDialog(playerid)
 {
-    ShowPlayerDialog(playerid, DIALOG_TEST_MENU, DIALOG_STYLE_LIST, "GameText+ Test Menu", 
-        "Normal GameTextForPlayer\nFormatted GameTextForPlayer\nNormal GameTextForAll\nFormatted GameTextForAll", 
+    ShowPlayerDialog(playerid, DIALOG_TEST_MENU, DIALOG_STYLE_LIST, "GameText+ Test Menu",
+        "Normal GameTextForPlayer\nFormatted GameTextForPlayer\nNormal GameTextForAll\nFormatted GameTextForAll",
         "Select", "Cancel");
     return true;
 }
@@ -157,7 +156,7 @@ forward ContinueStyleTest(playerid);
 public ContinueStyleTest(playerid)
 {
     if (!gPlayerShowingStyles[playerid]) return false;
-    
+
     gCurrentStyle[playerid]++;
     if (gCurrentStyle[playerid] > GAMETEXT_STYLE_MAX)
     {
@@ -167,7 +166,7 @@ public ContinueStyleTest(playerid)
         gPlayerShowingStyles[playerid] = false;
         return true;
     }
-    
+
     ShowCurrentStyle(playerid);
     return true;
 }
@@ -177,19 +176,19 @@ ShowCurrentStyle(playerid)
 {
     new Float:health, Float:armor, pname[MAX_PLAYER_NAME + 1];
     new score = GetPlayerScore(playerid);
-    
+
     GetPlayerHealth(playerid, health);
     GetPlayerArmour(playerid, armor);
     GetPlayerName(playerid, pname, sizeof(pname));
-    
+
     new string[128];
-    format(string, sizeof(string), "Showing style %d of %d", 
+    format(string, sizeof(string), "Showing style %d of %d",
         gCurrentStyle[playerid], GAMETEXT_STYLE_MAX);
     SendClientMessage(playerid, -1, string);
-    
+
     if (gTestType[playerid] == 0)
     {
-        switch(gCurrentStyle[playerid])// Normal GameText for Player
+        switch(gCurrentStyle[playerid]) // Normal GameText for Player
         {
             case 0: GameTextForPlayer(playerid, "~g~MISSION PASSED!~n~~w~Respect +100", 5000, 0);
             case 1: GameTextForPlayer(playerid, "~y~Player Connected~n~~w~Weapons Available", 5000, 1);
@@ -225,11 +224,11 @@ ShowCurrentStyle(playerid)
             case 7: GameTextForPlayer(playerid, "Vehicle: %s", 5000, 7, "NRG-500");
             case 8: GameTextForPlayer(playerid, "Area: %s", 5000, 8, "Grove Street");
             case 9: GameTextForPlayer(playerid, "Radio: %s", 5000, 9, "Los Santos");
-            case 10: GameTextForPlayer(playerid, "Finding: %s...", 5000, 10, "Station"); 
-            case 11: GameTextForPlayer(playerid, "+$%d", 5000, 11, 1000); 
-            case 12: GameTextForPlayer(playerid, "-$%d", 5000, 12, 250); 
-            case 13: GameTextForPlayer(playerid, "%s STUNT BONUS: $%d", 5000, 13, "INSANE", 500); 
-            case 14: GameTextForPlayer(playerid, "%02d:%02d", 5000, 14, gettime() / 60 % 60, gettime() % 60); 
+            case 10: GameTextForPlayer(playerid, "Finding: %s...", 5000, 10, "Station");
+            case 11: GameTextForPlayer(playerid, "+$%d", 5000, 11, 1000);
+            case 12: GameTextForPlayer(playerid, "-$%d", 5000, 12, 250);
+            case 13: GameTextForPlayer(playerid, "%s STUNT BONUS: $%d", 5000, 13, "INSANE", 500);
+            case 14: GameTextForPlayer(playerid, "%02d:%02d", 5000, 14, gettime() / 60 % 60, gettime() % 60);
             case 15: GameTextForPlayer(playerid, "~y~YOUR CONTROLS~n~~w~%s: Help Menu~n~%s: Options~n~%s: Statistics~n~%s: Quit", 5000, 15, "F1", "F2", "F3", "ESC");
             case 16: GameTextForPlayer(playerid, "~g~YOUR TIPS~n~~w~Current Score: %d~n~Health: %.1f~n~Armor: %.1f", 5000, 16, score, health, armor);
             case 17: GameTextForPlayer(playerid, "~w~%s, your mission is complete the reward is $%d", 5000, 17, pname, 1000);
@@ -247,16 +246,16 @@ ShowCurrentStyle(playerid)
             case 5: GameTextForAll("~y~SERVER STATUS~n~~w~Online: 50/100", 5000, 5);
             case 6: GameTextForAll("~b~WEATHER UPDATE~n~~w~Sunny", 5000, 6);
             case 7: GameTextForAll("New Vehicles Available", 5000, 7);
-            case 8: GameTextForAll("Los Santos Derby", 5000, 8); 
-            case 9: GameTextForAll("Radio: Server FM", 5000, 9); 
+            case 8: GameTextForAll("Los Santos Derby", 5000, 8);
+            case 9: GameTextForAll("Radio: Server FM", 5000, 9);
             case 10: GameTextForAll("Changing: Weather...", 5000, 10);
-            case 11: GameTextForAll("+$10000 Prize Pool", 5000, 11); 
-            case 12: GameTextForAll("-$5000 Entry Fee", 5000, 12); 
+            case 11: GameTextForAll("+$10000 Prize Pool", 5000, 11);
+            case 12: GameTextForAll("-$5000 Entry Fee", 5000, 12);
             case 13: GameTextForAll("SERVER EVENT: $1000 PRIZE", 5000, 13);
-            case 14: GameTextForAll("12:34", 5000, 14); 
-            case 15: GameTextForAll("~y~SERVER RULES~n~~w~No Cheating~n~No Spamming~n~Be Respectful~n~Have Fun", 5000, 15); 
+            case 14: GameTextForAll("12:34", 5000, 14);
+            case 15: GameTextForAll("~y~SERVER RULES~n~~w~No Cheating~n~No Spamming~n~Be Respectful~n~Have Fun", 5000, 15);
             case 16: GameTextForAll("~g~SERVER NEWS~n~~w~New weapons added~n~Map updated~n~Events every hour", 5000, 16);
-            case 17: GameTextForAll("~w~Upcoming server maintenance, please save your progress", 5000, 17); 
+            case 17: GameTextForAll("~w~Upcoming server maintenance, please save your progress", 5000, 17);
         }
     }
     else if (gTestType[playerid] == 3) // Formatted GameText for All
@@ -270,20 +269,20 @@ ShowCurrentStyle(playerid)
             case 4: GameTextForAll("~p~ADMIN ANNOUNCEMENT~n~~w~%s updated", 5000, 4, "Server Rules");
             case 5: GameTextForAll("~y~SERVER STATUS~n~~w~Online: %d/%d", 5000, 5, GetPlayerCount(), GetMaxPlayers());
             case 6: GameTextForAll("~b~WEATHER UPDATE~n~~w~%s", 5000, 6, "Thunderstorm");
-            case 7: GameTextForAll("%s now available", 5000, 7, "New Vehicles"); 
-            case 8: GameTextForAll("%s Event Area", 5000, 8, "Los Santos"); 
-            case 9: GameTextForAll("Radio: %s", 5000, 9, "Server FM"); 
-            case 10: GameTextForAll("Changing: %s...", 5000, 10, "Server Time"); 
-            case 11: GameTextForAll("+$%d Prize Pool", 5000, 11, 10000); 
-            case 12: GameTextForAll("-$%d Entry Fee", 5000, 12, 5000); 
-            case 13: GameTextForAll("%s EVENT: $%d PRIZE", 5000, 13, "SERVER", 1000); 
+            case 7: GameTextForAll("%s now available", 5000, 7, "New Vehicles");
+            case 8: GameTextForAll("%s Event Area", 5000, 8, "Los Santos");
+            case 9: GameTextForAll("Radio: %s", 5000, 9, "Server FM");
+            case 10: GameTextForAll("Changing: %s...", 5000, 10, "Server Time");
+            case 11: GameTextForAll("+$%d Prize Pool", 5000, 11, 10000);
+            case 12: GameTextForAll("-$%d Entry Fee", 5000, 12, 5000);
+            case 13: GameTextForAll("%s EVENT: $%d PRIZE", 5000, 13, "SERVER", 1000);
             case 14: GameTextForAll("%02d:%02d", 5000, 14, gettime() / 60 % 60, gettime() % 60);
-            case 15: GameTextForAll("~y~SERVER INFO~n~~w~Online: %d~n~Events: %d/day~n~Updates: Weekly", 5000, 15, GetPlayerCount(), 5); 
-            case 16: GameTextForAll("~g~SERVER NEWS~n~~w~New %s added~n~Map %s~n~Next event: %d min", 5000, 16, "weapons", "updated", 30); 
+            case 15: GameTextForAll("~y~SERVER INFO~n~~w~Online: %d~n~Events: %d/day~n~Updates: Weekly", 5000, 15, GetPlayerCount(), 5);
+            case 16: GameTextForAll("~g~SERVER NEWS~n~~w~New %s added~n~Map %s~n~Next event: %d min", 5000, 16, "weapons", "updated", 30);
             case 17: GameTextForAll("~w~%s Event starting, the pize pool is $%d", 5000, 17, "Stunt", 5000);
         }
     }
-    
+
     gTestActive[playerid] = SetTimerEx("ContinueStyleTest", 2500, false, "d", playerid);
 }
 


### PR DESCRIPTION
This is the final PR of here-and-there stuff I wanted to fix and solve before (probably) a new release if you don't mind 😄

1. Some styles natively has a feature of fading out, but not fading in (they just displayed instantly and then fading out after delay). These styles are 1, 15 and 16. In case with style 1 (it's basic gametext) this can be easily checked just in SA-MP without toggling `OVERRIDE_NATIVE_GAMETEXT`. As for styles 15 and 16, help message in singleplayer behaves the same and it can be checked by starting a new game and wait for the first game tip.
2. User error about incompatibility with fixes.inc was a bit changed to fit for both SA-MP and open.mp scripts
3. Added pawn.json for sampctl users (since .inc file is in subfolder, it's relevant) and tweaked formatting in test .pwn file