### PR TITLE
Some more improvements

### DIFF
--- a/include/gametext_plus.inc
+++ b/include/gametext_plus.inc
@@ -13,13 +13,13 @@
  *  Style 16 created by imshooter
  *  Assembly code created by __SyS__ and iAmir
  *  Style 17 created by Vince0789
- *  All the improvements on the include by NexiusTailer
+ *  All the improvements on the include by Nexius
 
  *  Thank you to y'all! <3
  */
 
 //==========================================================================
-//                          HEADER GUARDS & CHECKS
+//                         HEADER GUARDS & CHECKS
 //==========================================================================
 
 #if defined _INC_gametext_plus
@@ -80,7 +80,7 @@
 //! Developer used PRAGMA! It's super effective, compiler's warning level fell sharply!
 
 //==========================================================================
-//                          CONSTANTS & VARIABLES
+//                              MAIN CONSTANTS
 //==========================================================================
 
 #if defined OVERRIDE_NATIVE_GAMETEXT
@@ -89,12 +89,83 @@
     #define MIN_GAMETEXT_STYLE      7
 #endif
 
-#define     MAX_GAMETEXT_LENGTH     256
-#define     GAMETEXT_LEGACY         6
 #define     MAX_GAMETEXT_STYLE      17
+#define     GAMETEXT_LEGACY         6
+
+#define     MAX_GAMETEXT_LENGTH     256
 
 #define     FADE_INTERVAL           50
 #define     FADE_ALPHA_STEP         0x12
+
+//==========================================================================
+//                              DATA STRUCTURES
+//==========================================================================
+
+enum e_STYLE_DATA
+{
+    Float:e_pos[2],
+    Float:e_lettersize[2],
+    Float:e_textsize[2],
+    e_color,
+    e_bgalpha,
+    e_boxalpha,
+    e_shadow,
+    e_outline,
+    TEXT_DRAW_ALIGN:e_alignment,
+    TEXT_DRAW_FONT:e_font,
+    bool:e_proportional,
+    bool:e_fadein,
+    bool:e_fadeout
+};
+
+static const gs_StyleList[MAX_GAMETEXT_STYLE + 1][e_STYLE_DATA] =
+{
+    // Native Styles (0-6)
+
+    // Style 0 (Mission Passed)
+    {{320.0, 214.0}, {1.3, 3.6}, {200.0, 620.0}, 0x906210FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:3, true, true, true},
+    // Style 1 (Mission Name)
+    {{620.0, 310.0}, {1.0, 2.6}, {10.00, 200.0}, 0x906210FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:3, TEXT_DRAW_FONT:3, true, false, true},
+    // Style 2 (Wasted Style)
+    {{320.0, 156.0}, {2.1, 4.2}, {200.0, 620.0}, 0xE1E1E1FF, 0x000000AA, 0x00, 0, 3, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:0, true, true, true},
+    // Style 3 (Native Variations)
+    {{320.0, 154.5}, {0.6, 2.75}, {200.0, 620.0}, 0x906210FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:2, true, false, false},
+    // Style 4 (Native Variations)
+    {{320.0, 115.5}, {0.6, 2.75}, {200.0, 620.0}, 0x906210FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:2, true, false, false},
+    // Style 5 (Native Variations)
+    {{320.0, 217.0}, {0.6, 2.75}, {200.0, 620.0}, 0xE1E1E1FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:2, true, false, false},
+    // Style 6 (Native Variations)
+    {{320.0, 60.0}, {1.0, 3.6}, {200.0, 620.0}, 0xACCBF1FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:3, true, false, false},
+
+    // Enhanced Styles (7-17)
+
+    // Style 7 (Vehicle Name)
+    {{608.0, 344.0}, {1.0, 3.0}, {10.0, 200.0}, 0x36682CFF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:3, TEXT_DRAW_FONT:2, true, true, true},
+    // Style 8 (Location Name)
+    {{608.0, 385.8}, {1.2, 3.8}, {10.0, 200.0}, 0xACCBF1FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:3, TEXT_DRAW_FONT:0, true, true, true},
+    // Style 9 (Radio Station Name)
+    {{320.0, 22.0}, {0.6, 1.8}, {200.0, 620.0}, 0x906210FF, 0x000000AA, 0x00, 0, 1, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:2, true, false, false},
+    // Style 10 (Radio Station Name While Switching)
+    {{320.0, 22.0}, {0.6, 1.8}, {200.0, 620.0}, 0x969696FF, 0x000000AA, 0x00, 0, 1, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:2, true, false, false},
+    // Style 11 (Positive Money)
+    {{608.0, 77.0}, {0.55, 2.2}, {10.0, 200.0}, 0x36682CFF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:3, TEXT_DRAW_FONT:3, false, false, false},
+    // Style 12 (Negative Money)
+    {{608.0, 77.0}, {0.55, 2.2}, {10.0, 200.0}, 0xB4191DFF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:3, TEXT_DRAW_FONT:3, false, false, false},
+    // Style 13 (Stunt Bonus)
+    {{380.0, 341.15}, {0.58, 2.42}, {40.0, 460.0}, 0xE1E1E1FF, 0x000000AA, 0x00, 2, 0, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:1, true, false, false},
+    // Style 14 (In-Game Clock)
+    {{608.0, 22.0}, {0.55, 2.2}, {400.0, 20.0}, 0xE1E1E1FF, 0x000000AA, 0x00, 0, 2, TEXT_DRAW_ALIGN:3, TEXT_DRAW_FONT:3, false, false, false},
+    // Style 15 (Notification Popup)
+    {{34.0, 28.0}, {0.52, 2.2}, {230.5, 200.0}, 0xFFFFFF96, 0x00, 0x00000080, 0, 0, TEXT_DRAW_ALIGN:1, TEXT_DRAW_FONT:1, true, false, true},
+    // Style 16 (Lower Notification)
+    {{28.0, 150.0}, {0.42, 1.8}, {190.0, 200.0}, 0xFFFFFF96, 0x00, 0x00000080, 0, 0, TEXT_DRAW_ALIGN:1, TEXT_DRAW_FONT:1, true, false, true},
+    // Style 17 (Subtitles)
+    {{320.0, 368.1}, {0.58, 2.38}, {40.0, 460.0}, 0xE1E1E1FF, 0x000000AA, 0x00, 2, 0, TEXT_DRAW_ALIGN:2, TEXT_DRAW_FONT:1, true, false, false}
+};
+
+//==========================================================================
+//                                 VARIABLES
+//==========================================================================
 
 static
     Text:gs_GameTextStyle[MAX_GAMETEXT_STYLE + 1],
@@ -110,7 +181,7 @@ static
 ;
 
 //==========================================================================
-//                          FUNCTION REMAPPING
+//                            FUNCTION REMAPPING
 //==========================================================================
 
 #if defined _ALS_GameTextForPlayer
@@ -124,7 +195,7 @@ native ORIG_GameTextForPlayer(playerid, const string[], time, style) = GameTextF
 native ORIG_GameTextForAll(const string[], time, style) = GameTextForAll;
 
 //==========================================================================
-//                       TEXTDRAW COLOR STORAGE
+//                          TEXTDRAW COLOR STORAGE
 //==========================================================================
 
 /*
@@ -209,7 +280,7 @@ native ORIG_GameTextForAll(const string[], time, style) = GameTextForAll;
 #endif
 
 //==========================================================================
-//                          CORE FUNCTIONS
+//                              CORE FUNCTIONS
 //==========================================================================
 
 /*
@@ -218,711 +289,57 @@ native ORIG_GameTextForAll(const string[], time, style) = GameTextForAll;
  */
 static stock GameTextEx(playerid)
 {
-    new EMPTY_STRING[2] = " ";
-
     if (playerid == INVALID_PLAYER_ID)
     {
-        new Text:t;
+        for (new style = MIN_GAMETEXT_STYLE, Text:t; style <= MAX_GAMETEXT_STYLE; style++)
+        {
+            gs_GameTextStyle[style] = TextDrawCreate(gs_StyleList[style][e_pos][0], gs_StyleList[style][e_pos][1], " ");
+            t = gs_GameTextStyle[style];
 
-         #if defined OVERRIDE_NATIVE_GAMETEXT
-            // Native style 0
-            t = gs_GameTextStyle[0] = TextDrawCreate(320.0, 214.0, EMPTY_STRING);
-            TextDrawLetterSize(t, 1.3, 3.6);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
+            TextDrawLetterSize(t, gs_StyleList[style][e_lettersize][0], gs_StyleList[style][e_lettersize][1]);
+            TextDrawAlignment(t, gs_StyleList[style][e_alignment]);
             #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0x906210FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
+                TextDrawColour(t, SaveTextDrawColour(t, gs_StyleList[style][e_color]));
+                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, gs_StyleList[style][e_bgalpha]));
+                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, gs_StyleList[style][e_boxalpha]));
             #else
-                TextDrawColour(t, 0x906210FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
+                TextDrawColour(t, gs_StyleList[style][e_color]);
+                TextDrawBackgroundColour(t, gs_StyleList[style][e_bgalpha]);
+                TextDrawBoxColour(t, gs_StyleList[style][e_boxalpha]);
             #endif
-            TextDrawSetOutline(t, 2);
-            TextDrawFont(t, TEXT_DRAW_FONT:3);
-            TextDrawSetProportional(t, true);
+            TextDrawSetShadow(t, gs_StyleList[style][e_shadow]);
+            TextDrawSetOutline(t, gs_StyleList[style][e_outline]);
+            TextDrawFont(t, gs_StyleList[style][e_font]);
+            TextDrawSetProportional(t, gs_StyleList[style][e_proportional]);
+            TextDrawTextSize(t, gs_StyleList[style][e_textsize][0], gs_StyleList[style][e_textsize][1]);
             TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 200.0, 620.0);
-
-            // Native style 1
-            t = gs_GameTextStyle[1] = TextDrawCreate(620.0, 310.0, EMPTY_STRING);
-            TextDrawLetterSize(t, 1.0, 2.6);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
-            #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0x906210FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-            #else
-                TextDrawColour(t, 0x906210FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
-            #endif
-            TextDrawSetOutline(t, 2);
-            TextDrawFont(t, TEXT_DRAW_FONT:3);
-            TextDrawSetProportional(t, true);
-            TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 10.0, 200.0);
-
-            // Native style 2
-            t = gs_GameTextStyle[2] = TextDrawCreate(320.0, 156.0, EMPTY_STRING);
-            TextDrawLetterSize(t, 2.1, 4.2);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-            #else
-                TextDrawColour(t, 0xE1E1E1FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
-            #endif
-            TextDrawSetOutline(t, 3);
-            TextDrawFont(t, TEXT_DRAW_FONT:0);
-            TextDrawSetProportional(t, true);
-            TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 200.0, 620.0);
-
-            // Native style 3
-            t = gs_GameTextStyle[3] = TextDrawCreate(320.0, 154.5, EMPTY_STRING);
-            TextDrawLetterSize(t, 0.6, 2.75);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0x906210FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-            #else
-                TextDrawColour(t, 0x906210FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
-            #endif
-            TextDrawSetOutline(t, 2);
-            TextDrawFont(t, TEXT_DRAW_FONT:2);
-            TextDrawSetProportional(t, true);
-            TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 200.0, 620.0);
-
-            // Native style 4
-            t = gs_GameTextStyle[4] = TextDrawCreate(320.0, 115.5, EMPTY_STRING);
-            TextDrawLetterSize(t, 0.6, 2.75);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0x906210FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-            #else
-                TextDrawColour(t, 0x906210FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
-            #endif
-            TextDrawSetOutline(t, 2);
-            TextDrawFont(t, TEXT_DRAW_FONT:2);
-            TextDrawSetProportional(t, true);
-            TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 200.0, 620.0);
-
-            // Native style 5
-            t = gs_GameTextStyle[5] = TextDrawCreate(320.0, 217.0, EMPTY_STRING);
-            TextDrawLetterSize(t, 0.6, 2.75);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-            #else
-                TextDrawColour(t, 0xE1E1E1FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
-            #endif
-            TextDrawSetOutline(t, 2);
-            TextDrawFont(t, TEXT_DRAW_FONT:2);
-            TextDrawSetProportional(t, true);
-            TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 200.0, 620.0);
-
-            // Native style 6
-            t = gs_GameTextStyle[6] = TextDrawCreate(320.0, 60.0, EMPTY_STRING);
-            TextDrawLetterSize(t, 1.0, 3.6);
-            TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                TextDrawColour(t, SaveTextDrawColour(t, 0xACCBF1FF));
-                TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-                TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-            #else
-                TextDrawColour(t, 0xACCBF1FF);
-                TextDrawBackgroundColour(t, 0x000000AA);
-                TextDrawBoxColour(t, 0x00000000);
-            #endif
-            TextDrawSetOutline(t, 2);
-            TextDrawFont(t, TEXT_DRAW_FONT:3);
-            TextDrawSetProportional(t, true);
-            TextDrawUseBox(t, true);
-            TextDrawTextSize(t, 200.0, 620.0);
-        #endif
-
-        // Style 7 (Vehicle Name Style)
-        t = gs_GameTextStyle[7] = TextDrawCreate(608.0, 344.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 1.0, 3.0);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0x36682CFF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0x36682CFF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 2);
-        TextDrawFont(t, TEXT_DRAW_FONT:2);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 10.0, 200.0);
-
-        // Style 8 (Location Name Style)
-        t = gs_GameTextStyle[8] = TextDrawCreate(608.0, 385.8, EMPTY_STRING);
-        TextDrawLetterSize(t, 1.2, 3.8);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xACCBF1FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0xACCBF1FF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 2);
-        TextDrawFont(t, TEXT_DRAW_FONT:0);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 10.0, 200.0);
-
-        // Style 9 (Radio Station Name Style)
-        t = gs_GameTextStyle[9] = TextDrawCreate(320.0, 22.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.6, 1.8);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0x906210FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0x906210FF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 1);
-        TextDrawFont(t, TEXT_DRAW_FONT:2);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 200.0, 620.0);
-
-        // Style 10 (Radio Station Name While Switching Style)
-        t = gs_GameTextStyle[10] = TextDrawCreate(320.0, 22.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.6, 1.8);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0x969696FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0x969696FF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 1);
-        TextDrawFont(t, TEXT_DRAW_FONT:2);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 200.0, 620.0);
-
-        // Style 11 (Positive Money Style)
-        t = gs_GameTextStyle[11] = TextDrawCreate(608.0, 77.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.55, 2.2);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0x36682CFF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0x36682CFF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 2);
-        TextDrawFont(t, TEXT_DRAW_FONT:3);
-        TextDrawSetProportional(t, false);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 10.0, 200.0);
-
-        // Style 12 (Negative Money Style)
-        t = gs_GameTextStyle[12] = TextDrawCreate(608.0, 77.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.55, 2.2);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xB4191DFF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0xB4191DFF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 2);
-        TextDrawFont(t, TEXT_DRAW_FONT:3);
-        TextDrawSetProportional(t, false);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 10.0, 200.0);
-
-        // Style 13 (Stunt Bonus Style)
-        t = gs_GameTextStyle[13] = TextDrawCreate(380.0, 341.15, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.58, 2.42);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0xE1E1E1FF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetShadow(t, 2);
-        TextDrawSetOutline(t, 0);
-        TextDrawFont(t, TEXT_DRAW_FONT:1);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 40.0, 460.0);
-
-        // Style 14 (In-Game Clock Style)
-        t = gs_GameTextStyle[14] = TextDrawCreate(608.0, 22.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.55, 2.2);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0xE1E1E1FF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetOutline(t, 2);
-        TextDrawFont(t, TEXT_DRAW_FONT:3);
-        TextDrawSetProportional(t, false);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 400.0, 20.0);
-
-        // Style 15 (Notification Popup Style)
-        t = gs_GameTextStyle[15] = TextDrawCreate(34.0, 28.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.52, 2.2);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:1);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xFFFFFF96));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x00000000));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000080));
-        #else
-            TextDrawColour(t, 0xFFFFFF96);
-            TextDrawBackgroundColour(t, 0x00000000);
-            TextDrawBoxColour(t, 0x00000080);
-        #endif
-        TextDrawSetShadow(t, 0);
-        TextDrawSetOutline(t, 0);
-        TextDrawFont(t, TEXT_DRAW_FONT:1);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 230.5, 200.0);
-
-        // Style 16 (Lower Notification Style)
-        t = gs_GameTextStyle[16] = TextDrawCreate(28.0, 150.0, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.42, 1.8);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:1);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xFFFFFF96));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x00000000));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000080));
-        #else
-            TextDrawColour(t, 0xFFFFFF96);
-            TextDrawBackgroundColour(t, 0x00000000);
-            TextDrawBoxColour(t, 0x00000080);
-        #endif
-        TextDrawSetShadow(t, 0);
-        TextDrawSetOutline(t, 0);
-        TextDrawFont(t, TEXT_DRAW_FONT:1);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 212.0, 200.0);
-
-        // Style 17 (Subtitles Style)
-        t = gs_GameTextStyle[17] = TextDrawCreate(320.0, 368.1, EMPTY_STRING);
-        TextDrawLetterSize(t, 0.58, 2.38);
-        TextDrawAlignment(t, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            TextDrawColour(t, SaveTextDrawColour(t, 0xE1E1E1FF));
-            TextDrawBackgroundColour(t, SaveTextDrawBackgroundColour(t, 0x000000AA));
-            TextDrawBoxColour(t, SaveTextDrawBoxColour(t, 0x00000000));
-        #else
-            TextDrawColour(t, 0xE1E1E1FF);
-            TextDrawBackgroundColour(t, 0x000000AA);
-            TextDrawBoxColour(t, 0x00000000);
-        #endif
-        TextDrawSetShadow(t, 2);
-        TextDrawSetOutline(t, 0);
-        TextDrawFont(t, TEXT_DRAW_FONT:1);
-        TextDrawSetProportional(t, true);
-        TextDrawUseBox(t, true);
-        TextDrawTextSize(t, 40.0, 460.0);
+        }
     }
     else
     {
-        new PlayerText:pt;
+        for (new style = MIN_GAMETEXT_STYLE, PlayerText:pt; style <= MAX_GAMETEXT_STYLE; style++)
+        {
+            gs_PlayerGameTextStyle[playerid][style] = CreatePlayerTextDraw(playerid, gs_StyleList[style][e_pos][0], gs_StyleList[style][e_pos][1], " ");
+            pt = gs_PlayerGameTextStyle[playerid][style];
 
-        #if defined OVERRIDE_NATIVE_GAMETEXT
-            // Native style 0
-            pt = gs_PlayerGameTextStyle[playerid][0] = CreatePlayerTextDraw(playerid, 320.0, 214.0, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 1.3, 3.6);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
+            PlayerTextDrawLetterSize(playerid, pt, gs_StyleList[style][e_lettersize][0], gs_StyleList[style][e_lettersize][1]);
+            PlayerTextDrawAlignment(playerid, pt, gs_StyleList[style][e_alignment]);
             #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
+                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, gs_StyleList[style][e_color]));
+                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, gs_StyleList[style][e_bgalpha]));
+                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, gs_StyleList[style][e_boxalpha]));
             #else
-                PlayerTextDrawColour(playerid, pt, 0x906210FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
+                PlayerTextDrawColour(playerid, pt, gs_StyleList[style][e_color]);
+                PlayerTextDrawBackgroundColour(playerid, pt, gs_StyleList[style][e_bgalpha]);
+                PlayerTextDrawBoxColour(playerid, pt, gs_StyleList[style][e_boxalpha]);
             #endif
-            PlayerTextDrawSetOutline(playerid, pt, 2);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
-            PlayerTextDrawSetProportional(playerid, pt, true);
+            PlayerTextDrawSetShadow(playerid, pt, gs_StyleList[style][e_shadow]);
+            PlayerTextDrawSetOutline(playerid, pt, gs_StyleList[style][e_outline]);
+            PlayerTextDrawFont(playerid, pt, gs_StyleList[style][e_font]);
+            PlayerTextDrawSetProportional(playerid, pt, gs_StyleList[style][e_proportional]);
+            PlayerTextDrawTextSize(playerid, pt, gs_StyleList[style][e_textsize][0], gs_StyleList[style][e_textsize][1]);
             PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-            // Native style 1
-            pt = gs_PlayerGameTextStyle[playerid][1] = CreatePlayerTextDraw(playerid, 620.0, 310.0, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 1.0, 2.6);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
-            #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-            #else
-                PlayerTextDrawColour(playerid, pt, 0x906210FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-            #endif
-            PlayerTextDrawSetOutline(playerid, pt, 2);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
-            PlayerTextDrawSetProportional(playerid, pt, true);
-            PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 10.0, 200.0);
-
-            // Native style 2
-            pt = gs_PlayerGameTextStyle[playerid][2] = CreatePlayerTextDraw(playerid, 320.0, 156.0, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 2.1, 4.2);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-            #else
-                PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-            #endif
-            PlayerTextDrawSetOutline(playerid, pt, 3);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:0);
-            PlayerTextDrawSetProportional(playerid, pt, true);
-            PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-            // Native style 3
-            pt = gs_PlayerGameTextStyle[playerid][3] = CreatePlayerTextDraw(playerid, 320.0, 154.5, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 0.6, 2.75);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-            #else
-                PlayerTextDrawColour(playerid, pt, 0x906210FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-            #endif
-            PlayerTextDrawSetOutline(playerid, pt, 2);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
-            PlayerTextDrawSetProportional(playerid, pt, true);
-            PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-            // Native style 4
-            pt = gs_PlayerGameTextStyle[playerid][4] = CreatePlayerTextDraw(playerid, 320.0, 115.5, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 0.6, 2.75);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-            #else
-                PlayerTextDrawColour(playerid, pt, 0x906210FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-            #endif
-            PlayerTextDrawSetOutline(playerid, pt, 2);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
-            PlayerTextDrawSetProportional(playerid, pt, true);
-            PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-            // Native style 5
-            pt = gs_PlayerGameTextStyle[playerid][5] = CreatePlayerTextDraw(playerid, 320.0, 217.0, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 0.6, 2.75);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-            #else
-                PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-            #endif
-            PlayerTextDrawSetOutline(playerid, pt, 2);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
-            PlayerTextDrawSetProportional(playerid, pt, true);
-            PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-            // Native style 6
-            pt = gs_PlayerGameTextStyle[playerid][6] = CreatePlayerTextDraw(playerid, 320.0, 60.0, EMPTY_STRING);
-            PlayerTextDrawLetterSize(playerid, pt, 1.0, 3.6);
-            PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-            #if !defined _INC_open_mp
-                PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xACCBF1FF));
-                PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-                PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-            #else
-                PlayerTextDrawColour(playerid, pt, 0xACCBF1FF);
-                PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-                PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-            #endif
-            PlayerTextDrawSetOutline(playerid, pt, 2);
-            PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
-            PlayerTextDrawSetProportional(playerid, pt, true);
-            PlayerTextDrawUseBox(playerid, pt, true);
-            PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-        #endif
-
-        // Style 7 (Vehicle Name Style)
-        pt = gs_PlayerGameTextStyle[playerid][7] = CreatePlayerTextDraw(playerid, 608.0, 344.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 1.0, 3.0);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x36682CFF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0x36682CFF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 2);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 10.0, 200.0);
-
-        // Style 8 (Location Name Style)
-        pt = gs_PlayerGameTextStyle[playerid][8] = CreatePlayerTextDraw(playerid, 608.0, 385.8, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 1.2, 3.8);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xACCBF1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xACCBF1FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 2);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:0);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 10.0, 200.0);
-
-        // Style 9 (Radio Station Name Style)
-        pt = gs_PlayerGameTextStyle[playerid][9] = CreatePlayerTextDraw(playerid, 320.0, 22.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.6, 1.8);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x906210FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0x906210FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 1);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-        // Style 10 (Radio Station Name While Switching Style)
-        pt = gs_PlayerGameTextStyle[playerid][10] = CreatePlayerTextDraw(playerid, 320.0, 22.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.6, 1.8);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x969696FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0x969696FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 1);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:2);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 200.0, 620.0);
-
-        // Style 11 (Positive Money Style)
-        pt = gs_PlayerGameTextStyle[playerid][11] = CreatePlayerTextDraw(playerid, 608.0, 77.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.55, 2.2);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0x36682CFF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0x36682CFF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 2);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
-        PlayerTextDrawSetProportional(playerid, pt, false);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 10.0, 200.0);
-
-        // Style 12 (Negative Money Style)
-        pt = gs_PlayerGameTextStyle[playerid][12] = CreatePlayerTextDraw(playerid, 608.0, 77.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.55, 2.2);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xB4191DFF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xB4191DFF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 2);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
-        PlayerTextDrawSetProportional(playerid, pt, false);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 10.0, 200.0);
-
-        // Style 13 (Stunt Bonus Style)
-        pt = gs_PlayerGameTextStyle[playerid][13] = CreatePlayerTextDraw(playerid, 380.0, 341.15, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.58, 2.42);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetShadow(playerid, pt, 2);
-        PlayerTextDrawSetOutline(playerid, pt, 0);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:1);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 40.0, 460.0);
-
-        // Style 14 (In-Game Clock Style)
-        pt = gs_PlayerGameTextStyle[playerid][14] = CreatePlayerTextDraw(playerid, 608.0, 22.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.55, 2.2);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:3);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetOutline(playerid, pt, 2);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:3);
-        PlayerTextDrawSetProportional(playerid, pt, false);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 400.0, 20.0);
-
-        // Style 15 (Notification Popup Style)
-        pt = gs_PlayerGameTextStyle[playerid][15] = CreatePlayerTextDraw(playerid, 34.0, 28.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.52, 2.2);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x00000000));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000080));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xFFFFFF96);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x00000000);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000080);
-        #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
-        PlayerTextDrawSetOutline(playerid, pt, 0);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:1);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 230.5, 200.0);
-
-        // Style 16 (Lower Notification Style)
-        pt = gs_PlayerGameTextStyle[playerid][16] = CreatePlayerTextDraw(playerid, 28.0, 150.0, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.42, 1.8);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:1);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xFFFFFF96));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x00000000));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000080));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xFFFFFF96);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x00000000);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000080);
-        #endif
-        PlayerTextDrawSetShadow(playerid, pt, 0);
-        PlayerTextDrawSetOutline(playerid, pt, 0);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:1);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 212.0, 200.0);
-
-        // Style 17 (Subtitles Style)
-        pt = gs_PlayerGameTextStyle[playerid][17] = CreatePlayerTextDraw(playerid, 320.0, 368.1, EMPTY_STRING);
-        PlayerTextDrawLetterSize(playerid, pt, 0.58, 2.38);
-        PlayerTextDrawAlignment(playerid, pt, TEXT_DRAW_ALIGN:2);
-        #if !defined _INC_open_mp
-            PlayerTextDrawColour(playerid, pt, SavePlayerTextDrawColour(playerid, pt, 0xE1E1E1FF));
-            PlayerTextDrawBackgroundColour(playerid, pt, SavePlayerTextDrawBackgroundCol(playerid, pt, 0x000000AA));
-            PlayerTextDrawBoxColour(playerid, pt, SavePlayerTextDrawBoxColour(playerid, pt, 0x00000000));
-        #else
-            PlayerTextDrawColour(playerid, pt, 0xE1E1E1FF);
-            PlayerTextDrawBackgroundColour(playerid, pt, 0x000000AA);
-            PlayerTextDrawBoxColour(playerid, pt, 0x00000000);
-        #endif
-        PlayerTextDrawSetShadow(playerid, pt, 2);
-        PlayerTextDrawSetOutline(playerid, pt, 0);
-        PlayerTextDrawFont(playerid, pt, TEXT_DRAW_FONT:1);
-        PlayerTextDrawSetProportional(playerid, pt, true);
-        PlayerTextDrawUseBox(playerid, pt, true);
-        PlayerTextDrawTextSize(playerid, pt, 40.0, 460.0);
+        }
     }
     return true;
 }
@@ -935,7 +352,7 @@ static stock GameTextEx(playerid)
 forward OnHideGameText(playerid, styleid);
 public OnHideGameText(playerid, styleid)
 {
-    if (3 <= styleid <= 6 || 9 <= styleid <= 14 || styleid == 17)
+    if (!gs_StyleList[styleid][e_fadeout])
     {
         if (playerid == MAX_PLAYERS)
         {
@@ -1020,7 +437,7 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     const static_args = 4;
     const args_diff = (3 - static_args) * 4; // format's static args end at index 3, current function's end at static_arg_count. Also * 4 because cells are 4 bytes
 
-    static args, temp_string[256];
+    static args, temp_string[MAX_GAMETEXT_LENGTH];
     const string_size = sizeof(temp_string);
 
     args = numargs();
@@ -1083,16 +500,9 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     gs_GameTextIsFadingOut[style][playerid] = false;
     gs_GameTextIsFadingIn[style][playerid] = false;
 
-    if (!(3 <= style <= 6) && !(9 <= style <= 14) && style != 17)
-    {
-        gs_GameTextOriginalColor[style][playerid] = PlayerTextDrawGetColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
-        gs_GameTextOriginalBGColor[style][playerid] = PlayerTextDrawGetBackgroundCol(playerid, gs_PlayerGameTextStyle[playerid][style]);
-        gs_GameTextOriginalBoxColor[style][playerid] = PlayerTextDrawGetBoxColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
-    }
-
     if (args > static_args)
     {
-        static string[256];
+        static string[MAX_GAMETEXT_LENGTH];
         const string_size = sizeof(string);
 
         while (--args >= 4)
@@ -1120,21 +530,21 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
     }
     else
     {
-        #if defined _INC_open_mp
-            PlayerTextDrawSetString(playerid, gs_PlayerGameTextStyle[playerid][style], text);
-        #else
-            static string[MAX_GAMETEXT_LENGTH];
-            format(string, sizeof(string), "%s", text);
-            PlayerTextDrawSetString(playerid, gs_PlayerGameTextStyle[playerid][style], string);
-        #endif
+        static string[MAX_GAMETEXT_LENGTH];
+        format(string, sizeof(string), "%s", text);
+        PlayerTextDrawSetString(playerid, gs_PlayerGameTextStyle[playerid][style], string);
     }
 
-    if (style == 1 || 3 <= style <= 6 || 9 <= style <= 17)
+    if (!gs_StyleList[style][e_fadein])
     {
         PlayerTextDrawShow(playerid, gs_PlayerGameTextStyle[playerid][style]);
     }
     else
     {
+        gs_GameTextOriginalColor[style][playerid] = PlayerTextDrawGetColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
+        gs_GameTextOriginalBGColor[style][playerid] = PlayerTextDrawGetBackgroundCol(playerid, gs_PlayerGameTextStyle[playerid][style]);
+        gs_GameTextOriginalBoxColor[style][playerid] = PlayerTextDrawGetBoxColour(playerid, gs_PlayerGameTextStyle[playerid][style]);
+
         gs_GameTextIsFadingIn[style][playerid] = true;
         OnFadeInGameText(playerid, style, 0, 0, 0);
     }
@@ -1146,7 +556,6 @@ stock GTP_GameTextForPlayer(playerid, const text[], time, style, {Float, _}:...)
 
     return true;
 }
-
 
 /*
  * Enhanced GameTextForAll with support for extended styles
@@ -1166,7 +575,7 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
     const static_args = 3;
     const args_diff = (3 - static_args) * 4; // format's static args end at index 3, current function's end at static_arg_count. Also * 4 because cells are 4 bytes
 
-    static args, temp_string[256];
+    static args, temp_string[MAX_GAMETEXT_LENGTH];
     const string_size = sizeof(temp_string);
 
     args = numargs();
@@ -1229,16 +638,9 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
     gs_GameTextIsFadingOut[style][MAX_PLAYERS] = false;
     gs_GameTextIsFadingIn[style][MAX_PLAYERS] = false;
 
-    if (!(3 <= style <= 6) && !(9 <= style <= 14) && style != 17)
-    {
-        gs_GameTextOriginalColor[style][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[style]);
-        gs_GameTextOriginalBGColor[style][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[style]);
-        gs_GameTextOriginalBoxColor[style][MAX_PLAYERS] = TextDrawGetBoxColour(gs_GameTextStyle[style]);
-    }
-
     if (args > static_args)
     {
-        static string[256];
+        static string[MAX_GAMETEXT_LENGTH];
         const string_size = sizeof(string);
 
         while (--args >= 3)
@@ -1266,21 +668,21 @@ stock GTP_GameTextForAll(const text[], time, style, {Float, _}:...)
     }
     else
     {
-        #if defined _INC_open_mp
-            TextDrawSetString(gs_GameTextStyle[style], text);
-        #else
-            static string[MAX_GAMETEXT_LENGTH];
-            format(string, sizeof(string), "%s", text);
-            TextDrawSetString(gs_GameTextStyle[style], string);
-        #endif
+        static string[MAX_GAMETEXT_LENGTH];
+        format(string, sizeof(string), "%s", text);
+        TextDrawSetString(gs_GameTextStyle[style], string);
     }
 
-    if (style == 1 || 3 <= style <= 6 || 9 <= style <= 17)
+    if (!gs_StyleList[style][e_fadein])
     {
         TextDrawShowForAll(gs_GameTextStyle[style]);
     }
     else
     {
+        gs_GameTextOriginalColor[style][MAX_PLAYERS] = TextDrawGetColour(gs_GameTextStyle[style]);
+        gs_GameTextOriginalBGColor[style][MAX_PLAYERS] = TextDrawGetBackgroundColour(gs_GameTextStyle[style]);
+        gs_GameTextOriginalBoxColor[style][MAX_PLAYERS] = TextDrawGetBoxColour(gs_GameTextStyle[style]);
+
         gs_GameTextIsFadingIn[style][MAX_PLAYERS] = true;
         OnFadeInGameText(MAX_PLAYERS, style, 0, 0, 0);
     }
@@ -1331,7 +733,7 @@ public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, b
         {
             TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);
             TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha);
-            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
+            if (gs_StyleList[styleid][e_fadein])
             {
                 TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);
             }
@@ -1341,7 +743,7 @@ public OnFadeInGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, b
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | colourAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | backgroundColourAlpha);
-            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
+            if (gs_StyleList[styleid][e_fadein])
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | boxColourAlpha);
             }
@@ -1388,7 +790,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | colourAlpha);
             TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | backgroundColourAlpha);
-            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
+            if (gs_StyleList[styleid][e_fadeout])
             {
                 TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | boxColourAlpha);
             }
@@ -1398,7 +800,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | colourAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | backgroundColourAlpha);
-            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
+            if (gs_StyleList[styleid][e_fadeout])
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | boxColourAlpha);
             }
@@ -1419,7 +821,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             TextDrawColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalColor[styleid][MAX_PLAYERS] & ~0xFF) | origColorAlpha);
             TextDrawBackgroundColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBGColor[styleid][MAX_PLAYERS] & ~0xFF) | origBGAlpha);
-            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
+            if (gs_StyleList[styleid][e_fadeout])
             {
                 TextDrawBoxColour(gs_GameTextStyle[styleid], (gs_GameTextOriginalBoxColor[styleid][MAX_PLAYERS] & ~0xFF) | origBoxAlpha);
             }
@@ -1429,7 +831,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
         {
             PlayerTextDrawColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalColor[styleid][playerid] & ~0xFF) | origColorAlpha);
             PlayerTextDrawBackgroundColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBGColor[styleid][playerid] & ~0xFF) | origBGAlpha);
-            if (!(3 <= styleid <= 6) && !(9 <= styleid <= 14) && styleid != 17)
+            if (gs_StyleList[styleid][e_fadeout])
             {
                 PlayerTextDrawBoxColour(playerid, gs_PlayerGameTextStyle[playerid][styleid], (gs_GameTextOriginalBoxColor[styleid][playerid] & ~0xFF) | origBoxAlpha);
             }
@@ -1443,7 +845,7 @@ public OnFadeOutGameText(playerid, styleid, colourAlpha, backgroundColourAlpha, 
 }
 
 //==========================================================================
-//                          HOOKS & CALLBACKS
+//                            HOOKS & CALLBACKS
 //==========================================================================
 
 #define _ALS_GameTextForPlayer


### PR DESCRIPTION
1. Significantly reduce duplicated code by using data-driven approach
2. Omit checks [like those](https://github.com/itsneufox/GameText-Plus/blob/6792e71da0ed00a4dd39bb1abb34ce2e82b1a525/include/gametext_plus.inc#L938) in favor of [more readable flags](https://github.com/NexiusTailer/GameText-Plus/blob/11161418c7a882fc0ed27dd6625feb5854a6684c/include/gametext_plus.inc#L355)
3. Use existent macro `MAX_GAMETEXT_LENGTH` everywhere instead of raw value 256
4. Bound text length in any gametext to 256 chars regardless of using omp-stdlib, as it doesn't affect it anyhow (it's a clientside limitation)